### PR TITLE
fix: handle zip files without directory trees

### DIFF
--- a/src/renderer/unzip.ts
+++ b/src/renderer/unzip.ts
@@ -88,13 +88,13 @@ export class Unzipper {
     await fs.mkdirp(dir);
 
     const readStream = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
-      this.zipfile.openReadStream(entry, async (error: Error, stream: NodeJS.ReadableStream) => {
+      this.zipfile.openReadStream(entry, async (error: Error, zipStream: NodeJS.ReadableStream) => {
         if (error) {
           debug(`Encountered error while trying to read stream for ${entry.fileName}`);
           return reject(error);
         }
 
-        resolve(stream);
+        resolve(zipStream);
       });
     });
 

--- a/src/renderer/unzip.ts
+++ b/src/renderer/unzip.ts
@@ -1,6 +1,7 @@
 import yauzl from 'yauzl';
 import fs from 'fs-extra';
 import path from 'path';
+import * as stream from 'stream';
 import tmp from 'tmp';
 import { promisify } from 'util';
 
@@ -8,6 +9,7 @@ import { shouldIgnoreFile } from '../utils/should-ignore-file';
 import { UnzippedFile } from '../interfaces';
 
 const debug = require('debug')('sleuth:unzip');
+const pipeline = promisify(stream.pipeline);
 
 export interface YauzlZipEntry {
   fileName: string;
@@ -74,35 +76,39 @@ export class Unzipper {
     return fs.ensureDir(path.join(this.output, entry.fileName));
   }
 
-  public handleFile(entry: YauzlZipEntry): Promise<any> {
-    return new Promise<void>((resolve, reject) => {
-      const targetPath = path.join(this.output, entry.fileName);
+  public async handleFile(entry: YauzlZipEntry): Promise<any> {
+    const targetPath = path.join(this.output, entry.fileName);
 
-      debug(`Found file: ${entry.fileName}, Size: ${entry.compressedSize}.`);
+    debug(`Found file: ${entry.fileName}, Size: ${entry.compressedSize}.`);
 
-      if (shouldIgnoreFile(entry.fileName)) return;
+    if (shouldIgnoreFile(entry.fileName)) return;
 
-      this.zipfile.openReadStream(entry, async (error: Error, readStream: NodeJS.ReadableStream) => {
+    // Ensure the parent directory is created
+    const dir = path.dirname(targetPath);
+    await fs.mkdirp(dir);
+
+    const readStream = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+      this.zipfile.openReadStream(entry, async (error: Error, stream: NodeJS.ReadableStream) => {
         if (error) {
           debug(`Encountered error while trying to read stream for ${entry.fileName}`);
           return reject(error);
         }
 
-        readStream.pipe(fs.createWriteStream(targetPath));
-        readStream.once('end', () => {
-          this.files.push({
-            fileName: entry.fileName,
-            size: entry.uncompressedSize || 0,
-            fullPath: targetPath,
-            id: targetPath,
-            type: 'UnzippedFile'
-          });
-
-          debug(`Successfully unzipped ${entry.fileName} to ${targetPath}`);
-          resolve();
-        });
+        resolve(stream);
       });
     });
+
+    await pipeline(readStream, fs.createWriteStream(targetPath));
+
+    this.files.push({
+      fileName: entry.fileName,
+      size: entry.uncompressedSize || 0,
+      fullPath: targetPath,
+      id: targetPath,
+      type: 'UnzippedFile'
+    });
+
+    debug(`Successfully unzipped ${entry.fileName} to ${targetPath}`);
   }
 
   public async handleEntry(entry: YauzlZipEntry) {


### PR DESCRIPTION
Some zip files do not have separate directory trees, this can lead to us unzipping a file into a folder that does not yet exist.  Calling `mkdirp` on the parent directory of the target file ensures we never hit this case.