### PR TITLE
Update root-state-analytics.ts

### DIFF
--- a/src/renderer/analytics/root-state-analytics.ts
+++ b/src/renderer/analytics/root-state-analytics.ts
@@ -11,7 +11,7 @@ export function getRootStateWarnings(file: UnzippedFile): Array<string> {
 
   if (data.settings) {
     const { releaseChannelOverride } = data.settings;
-    if (releaseChannelOverride !== 'prod') {
+    if (releaseChannelOverride !== 'prod' && releaseChannelOverride !== null) {
       result.push(`Release channel is set to ${releaseChannelOverride}`);
     }
   }


### PR DESCRIPTION
Prevents root-state.json error when releaseChannelOverride is set to null, which is the normal state for external prod users