### PR TITLE
fix: update server file regex and fix "delete all" feature

### DIFF
--- a/src/renderer/components/welcome.tsx
+++ b/src/renderer/components/welcome.tsx
@@ -40,7 +40,7 @@ export class Welcome extends React.Component<WelcomeProps, Partial<WelcomeState>
 
   public renderSuggestions(): JSX.Element | null {
     const { openFile } = this.props.state;
-    const suggestions = this.props.state.suggestions || {};
+    const suggestions = this.props.state.suggestions || [];
     const elements = suggestions
       .map((file) => {
         const stats = file;
@@ -88,16 +88,15 @@ export class Welcome extends React.Component<WelcomeProps, Partial<WelcomeState>
   }
 
   public renderDeleteAll(): JSX.Element | null {
-    const suggestions = this.props.state.suggestions || {};
+    const suggestions = this.props.state.suggestions || [];
 
     // Do we have any files older than 48 hours?
     const twoDaysAgo = Date.now() - 172800000;
     const toDeleteAll: Array<string> = [];
 
-    Object.keys(suggestions).forEach((key) => {
-      const item = suggestions[key];
+    suggestions.forEach((item) => {
       if (isBefore(item.atimeMs, twoDaysAgo)) {
-        toDeleteAll.push(key);
+        toDeleteAll.push(item.filePath);
       }
     });
 

--- a/src/renderer/components/welcome.tsx
+++ b/src/renderer/components/welcome.tsx
@@ -95,7 +95,7 @@ export class Welcome extends React.Component<WelcomeProps, Partial<WelcomeState>
     const toDeleteAll: Array<string> = [];
 
     suggestions.forEach((item) => {
-      if (isBefore(item.atimeMs, twoDaysAgo)) {
+      if (isBefore(item.mtimeMs, twoDaysAgo)) {
         toDeleteAll.push(item.filePath);
       }
     });

--- a/src/renderer/suggestions.ts
+++ b/src/renderer/suggestions.ts
@@ -101,7 +101,7 @@ async function getSuggestions(input: Array<string>): Promise<Array<Suggestion>> 
     //
     // If the file is from #alerts-ios-logs, the server will h
     // have named it T8KJ1FXTL_U8KCVGGLR_1580765146766674.txt
-    const serverFormat = /\w{9,}_\w{9,}_\d{16,}\.(zip|txt)/;
+    const serverFormat = /\w{9,}_\w{9,}_\d{13,}(?:_\d)?\.(zip|txt)/;
     const logsFormat = /.*logs.*\.zip/;
     const iosLogsFormat = /Default_logs?.{0,5}.txt/;
     const androidLogsFormat = /attachment?.{0,5}.txt/;

--- a/test/renderer/rtl-new/welcome.test.tsx
+++ b/test/renderer/rtl-new/welcome.test.tsx
@@ -67,7 +67,7 @@ describe('Welcome', () => {
           {
             filePath: '/path/to/file/',
             age: 'dummy age string',
-            atimeMs: Date.now() - 1000 * 60 * 60 * 24 * 3 // 3 days old
+            mtimeMs: Date.now() - 1000 * 60 * 60 * 24 * 3 // 3 days old
           }
         ]
       };
@@ -82,7 +82,7 @@ describe('Welcome', () => {
           {
             filePath: '/path/to/file/',
             age: 'dummy age string',
-            atimeMs: Date.now() - 1000 * 60 * 60 * 24 * 1 // 1 day old
+            mtimeMs: Date.now() - 1000 * 60 * 60 * 24 * 1 // 1 day old
           }
         ]
       };


### PR DESCRIPTION
Was using Sleuth today and I noticed that server downloaded profiles never seem to show up in the suggestions list, and that the "Delete files older than 2 days" functionality didn't seem to work either. I updated both the regex and the delete code to fix both.

![recent](https://user-images.githubusercontent.com/44379112/146839906-ae8109dc-42cb-4f79-b195-0d1c50e16fe6.gif)

