### PR TITLE
fix: improve console log parsing and suggestions

### DIFF
--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -150,9 +150,10 @@ export function getTypeForFile(logFile: UnzippedFile): LogType {
     || fileName.startsWith('box')
     || fileName.startsWith('dropbox')
     || fileName.startsWith('unknown')
-    || fileName.endsWith('window-console.log')) {
+    || fileName.endsWith('window-console.log')
+    || fileName.endsWith('chrome-console.log')) {
     return LogType.RENDERER;
-  } else if (fileName.startsWith('webapp') || fileName.startsWith('app.slack') || fileName.startsWith('console-export')) {
+  } else if (fileName.startsWith('webapp') || fileName.startsWith('app.slack') || fileName.startsWith('console')) {
     return LogType.WEBAPP;
   } else if (fileName.startsWith('call')) {
     return LogType.CALL;
@@ -907,7 +908,7 @@ export function getMatchFunction(
   logFile: UnzippedFile
 ): (line: string) => MatchResult | undefined {
   if (logType === LogType.WEBAPP) {
-    if (logFile.fileName.startsWith('app.slack') || logFile.fileName.startsWith('console-export-')) {
+    if (logFile.fileName.startsWith('app.slack') || logFile.fileName.startsWith('console')) {
       return matchLineConsole;
     } else {
       return matchLineWebApp;

--- a/src/renderer/suggestions.ts
+++ b/src/renderer/suggestions.ts
@@ -106,7 +106,7 @@ async function getSuggestions(input: Array<string>): Promise<Array<Suggestion>> 
     const iosLogsFormat = /Default_logs?.{0,5}.txt/;
     const androidLogsFormat = /attachment?.{0,5}.txt/;
     const chromeLogsFormat = /app\.slack\.com\-\d{13,}\.log/;
-    const firefoxLogsFormat = /console-export-[\d\-\_]{12,}\.txt/;
+    const firefoxLogsFormat = /console(-export)?[\d\-\_]{0,22}\.(txt|log)/;
     const shouldAdd = logsFormat.test(file)
     || serverFormat.test(file)
     || iosLogsFormat.test(file)


### PR DESCRIPTION
- Recognize files starting in `console` as console logs (vs requiring `console-export-`)
- Suggests files starting in `console` on the home screen