### PR TITLE
fix: console logs no longer use incorrect timestamps

### DIFF
--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -400,7 +400,7 @@ export function readFile(
         }
 
         // Deal with leading Android debug log lines with no timestamp that were given the Jan 1970 default
-        if (logType === 'mobile' && current?.timestamp === new Date('Jan-01-70 00:00:00').toString()) {
+        if ((logType === 'mobile' || logType === 'webapp') && current?.timestamp === new Date('Jan-01-70 00:00:00').toString()) {
           // If a debug line isn't currently being stored
           if (!androidDebug) {
             // Copy the current log entry to the debug store
@@ -410,7 +410,7 @@ export function readFile(
             androidDebug.message += '\n' + current?.message;
           }
         // If a debug line is stored and current exists
-        } else if (logType === 'mobile' && androidDebug && current) {
+        } else if ((logType === 'mobile' || logType === 'webapp') && androidDebug && current) {
           // Give the debug line current's timestamp and momentvalue and push it separately
           androidDebug.timestamp = current.timestamp;
           androidDebug.momentValue = current.momentValue;


### PR DESCRIPTION
- branch name is wrong because I thought it was an Android issue at first lol
- I give debug lines in Android & browser with no timestamps a default 1970 date, then convert 1970 to the first actual date that appears in the logs - did it for Android, forgot to do it for console logs