### PR TITLE
feat: add trace start, end, and duration

### DIFF
--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -110,11 +110,18 @@ export class DevtoolsView extends React.Component<
     const hasThreads = !!rendererThreads?.length;
     const missingThreads = rendererThreads?.length === 0;
     const isLoading = !rendererThreads;
+    const startTime = parseInt(this.props.file.fileName.split('.')[0]?.split('_')[4] || '0', 10);
+    const endTime = parseInt(this.props.file.fileName.split('.')[0]?.split('_')[0] || '0', 10);
+    const duration = endTime - startTime;
 
     return (
       <div className='ProcessTable'>
         <Card>
           <h1>Renderer Threads</h1>
+          <h4>Duration: {duration ? Math.floor(duration/1000).toString() : 'unknown'} seconds 
+          {' '}| Trace started: {startTime ? new Date(startTime).toLocaleString() : 'unknown'}
+          {' '}| Trace ended: {endTime ? new Date(endTime).toLocaleString() : 'unknown'}</h4>
+          <h5>* Start & end times displayed in your local time</h5>
           <HTMLTable>
             <thead>
               <tr>

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -118,7 +118,7 @@ export class DevtoolsView extends React.Component<
       <div className='ProcessTable'>
         <Card>
           <h1>Renderer Threads</h1>
-          <h4>Duration: {duration ? Math.floor(duration/1000).toString() : 'unknown'} seconds 
+          <h4>Duration: {duration ? Math.floor(duration / 1000).toString() : 'unknown'} seconds
           {' '}| Trace started: {startTime ? new Date(startTime).toLocaleString() : 'unknown'}
           {' '}| Trace ended: {endTime ? new Date(endTime).toLocaleString() : 'unknown'}</h4>
           <h5>* Start & end times displayed in your local time</h5>

--- a/src/renderer/styles/devtools.less
+++ b/src/renderer/styles/devtools.less
@@ -17,3 +17,20 @@
   width: 100%;
   table-layout: fixed;
 }
+
+.ProcessTable h1 {
+  margin-bottom: 0;
+  font-weight: normal;
+}
+
+.ProcessTable h4 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: normal;
+}
+
+.ProcessTable h5 {
+  font-style: italic;
+  font-weight: normal;
+  margin-top: 0;
+}


### PR DESCRIPTION
- Performance profiles now display duration in seconds, start time, and end time

<img width="752" alt="image" src="https://user-images.githubusercontent.com/46466811/157997050-6962ebc0-52c5-47c8-a9d3-9a319a6bec60.png">
