### PR TITLE
fix: console log lines now have proper timestamps

### DIFF
--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -404,7 +404,7 @@ export function readFile(
 
         // Deal with leading Android debug log lines with no timestamp that were given the Jan 1970 default
         // and console log lines given 'No Date'
-        if ((logType === 'mobile' || logType === 'webapp') && 
+        if ((logType === 'mobile' || logType === 'webapp') &&
         (current?.timestamp === new Date('Jan-01-70 00:00:00').toString() || current?.timestamp.startsWith('No Date'))) {
           // If a debug line isn't currently being stored
           if (!androidDebug) {
@@ -418,7 +418,7 @@ export function readFile(
         } else if ((logType === 'mobile' || logType === 'webapp') && androidDebug && current) {
           if (androidDebug.timestamp.startsWith('No Date')) {
             // If it's a console log with only the timestamp, give it the date of the next possible log line
-            androidDebug.timestamp = current.timestamp.substring(0, 16) + androidDebug.timestamp.substring(7)
+            androidDebug.timestamp = current.timestamp.substring(0, 16) + androidDebug.timestamp.substring(7);
             androidDebug.momentValue = new Date(androidDebug.timestamp).valueOf();
           } else {
             // Give the debug line current's timestamp and momentvalue and push it separately


### PR DESCRIPTION
Two types of logs have weird timestamps:
- Some Android logs have no timestamp at all. In that case, we store those lines until we come across a line that _does_ have a timestamp. Then we give the stored lines that new timestamp and push it as one line.
- Some console logs have a time, but not date. In that case, we store those lines until we come across a line that does have a complete timestamp (i.e. date + time). Then we give the stored lines the new date, append the existing time, and push it as one line.