### PR TITLE
feat: add support for electron_debug.log

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,7 @@ export const enum LogType {
   INSTALLER = 'installer',
   ALL = 'all',
   MOBILE = 'mobile',
+  CHROMIUM = 'chromium',
   UNKNOWN = ''
 }
 
@@ -41,7 +42,8 @@ export const LOG_TYPES_TO_PROCESS = [
   LogType.PRELOAD,
   LogType.CALL,
   LogType.INSTALLER,
-  LogType.MOBILE
+  LogType.MOBILE,
+  LogType.CHROMIUM
 ];
 
 export interface Bookmark {
@@ -143,6 +145,7 @@ export interface ProcessedLogFiles {
   trace: Array<UnzippedFile>;
   installer: Array<UnzippedFile>;
   mobile: Array<UnzippedFile>;
+  chromium: Array<UnzippedFile>;
 }
 
 export interface MergedLogFile extends BaseFile {
@@ -163,6 +166,7 @@ export interface SortedUnzippedFiles {
   trace: Array<UnzippedFile>;
   installer: Array<UnzippedFile>;
   mobile: Array<UnzippedFile>;
+  chromium: Array<UnzippedFile>;
 }
 
 export interface MergedFilesLoadStatus {

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -55,6 +55,7 @@ export class CoreApplication extends React.Component<CoreAppProps, Partial<CoreA
         netlog: [],
         trace: [],
         mobile: [],
+        chromium: [],
       },
       loadingMessage: '',
       loadedLogFiles: false,

--- a/src/renderer/components/log-line-details/data.tsx
+++ b/src/renderer/components/log-line-details/data.tsx
@@ -74,7 +74,7 @@ export class LogLineData extends React.PureComponent<LogLineDataProps, LogLineDa
     const str = `https://source.chromium.org/search?q=LOG%20filepath:${selectedEntry.meta.sourceFile}&ss=chromium`;
 
     return <div className='LogLineData'>
-      <AnchorButton href={str} icon="search">Search the log in the Chromium source</AnchorButton>
+      <AnchorButton href={str} icon='search'>Search the log in the Chromium source</AnchorButton>
     </div>;
   }
 

--- a/src/renderer/components/log-line-details/data.tsx
+++ b/src/renderer/components/log-line-details/data.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { JSONView } from '../json-view';
-import { Card, Elevation } from '@blueprintjs/core';
+import { AnchorButton, Card, Elevation } from '@blueprintjs/core';
 import { SleuthState } from '../../state/sleuth';
+import { LogEntry } from '../../../interfaces';
 
 const debug = require('debug')('sleuth:data');
 
 export interface LogLineDataProps {
-  raw: string;
+  meta: any;
   state: SleuthState;
 }
 
@@ -19,9 +20,6 @@ export class LogLineData extends React.PureComponent<LogLineDataProps, LogLineDa
 
   /**
    * Renders pretty JSON
-   *
-   * @param {string} raw
-   * @returns {JSX.Element}
    */
   public renderJSON(raw: string): JSX.Element {
     return (
@@ -35,9 +33,6 @@ export class LogLineData extends React.PureComponent<LogLineDataProps, LogLineDa
 
   /**
    * Renders a ASCII table as a pretty table
-   *
-   * @param {string} raw
-   * @returns {JSX.Element}
    */
   public renderTable(raw: string): JSX.Element {
     const headerRgx = /^(\+|\|)-[+-]*-\+\s*$/;
@@ -75,20 +70,39 @@ export class LogLineData extends React.PureComponent<LogLineDataProps, LogLineDa
     return (<div className='LogLineData'>{data}</div>);
   }
 
+  public renderChromiumFile(selectedEntry: LogEntry) {
+    const str = `https://source.chromium.org/search?q=LOG%20filepath:${selectedEntry.meta.sourceFile}&ss=chromium`;
+
+    return <div className='LogLineData'>
+      <AnchorButton href={str} icon="search">Search the log in the Chromium source</AnchorButton>
+    </div>;
+  }
+
   /**
-   * Takes a meta string (probably dirty JSON) and attempts to pretty-print it.
-   *
-   * @returns {(JSX.Element | null)}
+   * Takes metadata (probably dirty JSON) and attempts to pretty-print it.
    */
   public render(): JSX.Element | null {
-    const { raw } = this.props;
+    const { meta } = this.props;
 
-    if (!raw) {
+    if (!meta) {
       return null;
-    } else if (raw && raw.startsWith(`+----`) && raw.endsWith('----+\n')) {
-      return this.renderTable(raw);
-    } else {
-      return this.renderJSON(raw);
     }
+
+    // string
+    if (typeof meta === 'string') {
+      if (meta && meta.startsWith(`+----`) && meta.endsWith('----+\n')) {
+        return this.renderTable(meta);
+      } else {
+        return this.renderJSON(meta);
+      }
+    }
+
+    // object
+    if (meta.sourceFile) {
+      const { selectedEntry } = this.props.state;
+      return this.renderChromiumFile(selectedEntry!);
+    }
+
+    return null;
   }
 }

--- a/src/renderer/components/log-line-details/details.tsx
+++ b/src/renderer/components/log-line-details/details.tsx
@@ -125,7 +125,7 @@ export class LogLineDetails extends React.Component<LogLineDetailsProps, LogLine
     }
 
     return (
-      <LogLineData state={this.props.state} raw={selectedEntry?.meta || ''} />
+      <LogLineData state={this.props.state} meta={selectedEntry?.meta} />
     );
   }
 

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -34,7 +34,8 @@ const enum NODE_ID {
   INSTALLER = 'installer',
   NETWORK = 'network',
   CACHE = 'cache',
-  MOBILE = 'mobile'
+  MOBILE = 'mobile',
+  CHROMIUM = 'chromium',
 }
 
 const DEFAULT_NODES: Array<ITreeNode> = [
@@ -67,6 +68,12 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     isExpanded: true,
     childNodes: [],
     nodeData: { type: 'trace' }
+  }, {
+    id: NODE_ID.CHROMIUM,
+    hasCaret: true,
+    icon: 'modal',
+    label: 'Chromium',
+    isExpanded: true
   }, {
     id: NODE_ID.RENDERER,
     hasCaret: true,
@@ -143,7 +150,7 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
     Sidebar.setChildNodes(NODE_ID.NETWORK, state, processedLogFiles.netlog.map((file, i) => Sidebar.getNetlogFileNode(file, props, i)));
     Sidebar.setChildNodes(NODE_ID.MOBILE, state, processedLogFiles.mobile.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.TRACE, state, processedLogFiles.trace.map((file) => Sidebar.getStateFileNode(file, props)));
-
+    Sidebar.setChildNodes(NODE_ID.CHROMIUM, state, processedLogFiles.chromium.map((file) => Sidebar.getFileNode(file, props)));
 
     return { nodes: state.nodes };
   }

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -31,7 +31,7 @@ const SHIPIT_MAC_RGX = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) (.*)$/;
 const SQUIRREL_RGX = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})> (.*)$/;
 
 // [70491:0302/160742.806582:WARNING:gpu_process_host.cc(1303)] The GPU process has crashed 1 time(s)
-const CHROMIUM_RGX = /^\[(\d+:\d{4}\/\d{6}\.\d{6}:[a-zA-Z]+:.*\(\d+\))\] (.*)$/;
+const CHROMIUM_RGX = /^\[(\d+:\d{4}\/\d{6}\.\d{3,6}:[a-zA-Z]+:.*\(\d+\))\] (.*)$/;
 
 /**
  * Sort an array, but do it on a different thread

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -927,7 +927,7 @@ export function matchLineChromium(line: string): MatchResult | undefined {
     return undefined;
   }
 
-  const [_log, metadata, message] = results;
+  const [, metadata, message] = results;
   const [pid, timestamp, level, sourceFile] = metadata.split(':');
   const currentDate = new Date();
 
@@ -956,7 +956,7 @@ export function matchLineChromium(line: string): MatchResult | undefined {
     WARNING: 'warn',
     INFO: 'info',
     ERROR: 'error',
-  }
+  };
 
   return {
     level: LEVEL_MAP[level],

--- a/test/utils/get-first-logfile.test.ts
+++ b/test/utils/get-first-logfile.test.ts
@@ -22,7 +22,8 @@ const files: ProcessedLogFiles = {
   netlog: [],
   installer: [],
   trace: [],
-  mobile: []
+  mobile: [],
+  chromium: [],
 };
 
 describe('getFirstLogFile', () => {


### PR DESCRIPTION
This PR adds support for `electron_debug.log` in Sleuth. Chromium logs have a unique format that requires a whole other set of parsers.

A log line looks something like this:
```
[85509:0307/160606.126448:WARNING:transport_feedback_adapter.cc(263)] Failed to lookup send time for 1 packet. Send time history too small?
```

Here, the metadata prefixing the message is `[process_id:MMDD/hhmmss.SSSSSS:LOG_LEVEL:filename(line)]` as documented in https://support.google.com/chrome/a/answer/6271282.

Some notes:
* The timestamp is approximate: we don't have year information, but we assume that logs are fresh and sent within the last year or so.
* Log levels are not standard, so I mapped some obvious ones to the ones that Sleuth uses.
* We can actually link to Chrome's source to find the code where the log file lives! For example: https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc?q=filepath:transport_feedback_adapter.cc&ss=chromium