### PR TITLE
fix: order log filters by log levels

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -186,10 +186,10 @@ export interface Suggestion extends fs.Stats {
 }
 
 export enum LogLevel {
+  debug = 'debug',
   info = 'info',
-  error = 'error',
   warn = 'warn',
-  debug = 'debug'
+  error = 'error'
 }
 
 export type LogMetrics = Record<LogLevel, number>;

--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -80,11 +80,11 @@ export class Filter extends React.Component<FilterProps, Partial<FilterState>> {
     const menu = (
       <Menu>
         <Menu.Item
-          active={warn}
-          onClick={() => this.props.state.onFilterToggle('warn')}
-          icon='warning-sign'
+          active={debug}
+          onClick={() => this.props.state.onFilterToggle('debug')}
+          icon='code'
           shouldDismissPopover={false}
-          text='Warning'
+          text='Debug'
         />
         <Menu.Item
           active={info}
@@ -94,18 +94,18 @@ export class Filter extends React.Component<FilterProps, Partial<FilterState>> {
           text='Info'
         />
         <Menu.Item
+          active={warn}
+          onClick={() => this.props.state.onFilterToggle('warn')}
+          icon='warning-sign'
+          shouldDismissPopover={false}
+          text='Warning'
+        />
+        <Menu.Item
           active={error}
           onClick={() => this.props.state.onFilterToggle('error')}
           icon='error'
           shouldDismissPopover={false}
           text='Error'
-        />
-        <Menu.Item
-          active={debug}
-          onClick={() => this.props.state.onFilterToggle('debug')}
-          icon='code'
-          shouldDismissPopover={false}
-          text='Debug'
         />
       </Menu>
     );


### PR DESCRIPTION
Fixes #71 by rearranging the order of the Menu items in the App Header and in the interface's Log Level in the Renderer.
Importance: Rearranged the order to match order convention (Example: Order in Devtools).