### PR TITLE
refactor: `suppressImplicitAnyIndexErrors: false`

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,31 +27,23 @@ export enum LogType {
 export type KnownLogType = Exclude<LogType, LogType.UNKNOWN | LogType.ALL>;
 export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 
-export type ProcessedLogFiles = Record<KnownLogType, Array<ProcessedLogFile>>;
+export const LOG_TYPES_TO_PROCESS = [
+  LogType.BROWSER,
+  LogType.RENDERER,
+  LogType.WEBAPP,
+  LogType.PRELOAD,
+  LogType.CALL,
+  LogType.INSTALLER,
+  LogType.MOBILE,
+  LogType.CHROMIUM
+] as const;
+
+export type ProcessableLogType = (typeof LOG_TYPES_TO_PROCESS)[number];
+
+export type RawLogType = Exclude<KnownLogType, ProcessableLogType>;
+
+export type ProcessedLogFiles = Record<ProcessableLogType, Array<ProcessedLogFile>> & Record<RawLogType, Array<UnzippedFile>>;
 export type SortedUnzippedFiles = Record<KnownLogType, Array<UnzippedFile>>;
-
-export const ALL_LOG_TYPES: Array<KnownLogType> = [
-  LogType.BROWSER,
-  LogType.RENDERER,
-  LogType.CALL,
-  LogType.WEBAPP,
-  LogType.PRELOAD,
-  LogType.NETLOG,
-  LogType.INSTALLER,
-  LogType.MOBILE,
-  LogType.CHROMIUM
-];
-
-export const LOG_TYPES_TO_PROCESS: Array<KnownLogType> = [
-  LogType.BROWSER,
-  LogType.RENDERER,
-  LogType.WEBAPP,
-  LogType.PRELOAD,
-  LogType.CALL,
-  LogType.INSTALLER,
-  LogType.MOBILE,
-  LogType.CHROMIUM
-];
 
 export interface Bookmark {
   logEntry: LogEntry;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,22 +8,29 @@ export type LogFile = MergedLogFile | ProcessedLogFile;
 
 export type RepeatedCounts = Record<string, number>;
 
-export const enum LogType {
-  TRACE = 'trace',
+export enum LogType {
+  ALL = 'all',
   BROWSER = 'browser',
   RENDERER = 'renderer',
-  CALL = 'call',
-  WEBAPP = 'webapp',
   PRELOAD = 'preload',
+  WEBAPP = 'webapp',
+  STATE = 'state',
+  CALL = 'call',
   NETLOG = 'netlog',
+  TRACE = 'trace',
   INSTALLER = 'installer',
-  ALL = 'all',
   MOBILE = 'mobile',
   CHROMIUM = 'chromium',
-  UNKNOWN = ''
+  UNKNOWN = 'unknown',
 }
 
-export const ALL_LOG_TYPES = [
+export type KnownLogType = Exclude<LogType, LogType.UNKNOWN | LogType.ALL>;
+export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
+
+export type ProcessedLogFiles = Record<KnownLogType, Array<ProcessedLogFile>>;
+export type SortedUnzippedFiles = Record<KnownLogType, Array<UnzippedFile>>;
+
+export const ALL_LOG_TYPES: Array<KnownLogType> = [
   LogType.BROWSER,
   LogType.RENDERER,
   LogType.CALL,
@@ -31,11 +38,11 @@ export const ALL_LOG_TYPES = [
   LogType.PRELOAD,
   LogType.NETLOG,
   LogType.INSTALLER,
-  LogType.ALL,
-  LogType.MOBILE
+  LogType.MOBILE,
+  LogType.CHROMIUM
 ];
 
-export const LOG_TYPES_TO_PROCESS = [
+export const LOG_TYPES_TO_PROCESS: Array<KnownLogType> = [
   LogType.BROWSER,
   LogType.RENDERER,
   LogType.WEBAPP,
@@ -67,7 +74,7 @@ export type CompressedBookmark = [ number, number, string, number ];
 
 export interface ProcessorPerformanceInfo {
   name: string;
-  type: LogType;
+  type: SelectableLogType;
   lines: number;
   entries: number;
   processingTime: number;
@@ -82,7 +89,7 @@ export interface LogEntry {
   index: number;
   timestamp: string;
   message: string;
-  level: string;
+  level: LogLevel;
   logType: LogType;
   line: number;
   sourceFile: string;
@@ -114,59 +121,22 @@ export interface UnzippedFile extends BaseFile {
 
 export interface UnzippedFiles extends Array<UnzippedFile> { }
 
-export interface MergedLogFiles {
-  all: MergedLogFile;
-  browser: MergedLogFile;
-  renderer: MergedLogFile;
-  webapp: MergedLogFile;
-  preload: MergedLogFile;
-  call: MergedLogFile;
-  mobile: MergedLogFile;
-  type: 'MergedLogFiles';
-}
+export type MergedLogFiles = Record<SelectableLogType, MergedLogFile>;
 
 export interface ProcessedLogFile extends BaseFile {
   levelCounts: Record<string, number>;
   repeatedCounts: RepeatedCounts;
   logEntries: Array<LogEntry>;
   logFile: UnzippedFile;
-  logType: LogType;
+  logType: KnownLogType;
   type: 'ProcessedLogFile';
-}
-
-export interface ProcessedLogFiles {
-  browser: Array<ProcessedLogFile>;
-  renderer: Array<ProcessedLogFile>;
-  preload: Array<ProcessedLogFile>;
-  webapp: Array<ProcessedLogFile>;
-  state: Array<UnzippedFile>;
-  call: Array<ProcessedLogFile>;
-  netlog: Array<UnzippedFile>;
-  trace: Array<UnzippedFile>;
-  installer: Array<UnzippedFile>;
-  mobile: Array<UnzippedFile>;
-  chromium: Array<UnzippedFile>;
 }
 
 export interface MergedLogFile extends BaseFile {
   logFiles: Array<ProcessedLogFile>;
   logEntries: Array<LogEntry>;
-  logType: LogType;
+  logType: SelectableLogType;
   type: 'MergedLogFile';
-}
-
-export interface SortedUnzippedFiles {
-  browser: Array<UnzippedFile>;
-  renderer: Array<UnzippedFile>;
-  preload: Array<UnzippedFile>;
-  webapp: Array<UnzippedFile>;
-  state: Array<UnzippedFile>;
-  call: Array<UnzippedFile>;
-  netlog: Array<UnzippedFile>;
-  trace: Array<UnzippedFile>;
-  installer: Array<UnzippedFile>;
-  mobile: Array<UnzippedFile>;
-  chromium: Array<UnzippedFile>;
 }
 
 export interface MergedFilesLoadStatus {
@@ -192,22 +162,14 @@ export enum LogLevel {
   error = 'error'
 }
 
+export type LevelFilter = Record<LogLevel, boolean>;
 export type LogMetrics = Record<LogLevel, number>;
 export type TimeBucketedLogMetrics = Record<number, LogMetrics>;
-
-export interface LevelFilter {
-  error: boolean;
-  info: boolean;
-  debug: boolean;
-  warn: boolean;
-}
 
 export interface TouchBarLogFileUpdate {
   levelCounts: Record<string, number>;
   isLogFile: boolean;
 }
-
-export type Suggestions = Array<Suggestion>;
 
 export enum Tool {
   cache = 'cache'

--- a/src/main/touch-bar-manager.ts
+++ b/src/main/touch-bar-manager.ts
@@ -10,7 +10,7 @@ import { getNiceGreeting } from '../utils/get-nice-greeting';
 import { levelsHave } from '../utils/level-counts';
 import { plural } from '../utils/pluralize';
 import { TOUCHBAR_IPC, STATE_IPC } from '../shared-constants';
-import { LevelFilter, TouchBarLogFileUpdate } from '../interfaces';
+import { LevelFilter, LogLevel, TouchBarLogFileUpdate } from '../interfaces';
 
 const {
   TouchBarButton,
@@ -220,7 +220,7 @@ export class TouchBarManager {
     if (!this.isRightSender(event)) return;
 
     Object.keys(levelFilter)
-      .forEach((key) => {
+      .forEach((key: LogLevel) => {
         this.toggleFilterBtns[key].backgroundColor = levelFilter[key]
           ? '#ffffff'
           : '#4d5a68';
@@ -286,7 +286,7 @@ export class TouchBarManager {
     return event.sender.id === this.browserWindow.webContents?.id;
   }
 
-  private send(channel: string, ...args: Array<any>) {
+  private send(channel: string, ...args: Array<unknown>) {
     this.browserWindow.webContents?.send(channel, ...args);
   }
 }

--- a/src/renderer/analytics/notification-warning-analytics.tsx
+++ b/src/renderer/analytics/notification-warning-analytics.tsx
@@ -62,14 +62,16 @@ export const categoryDescriptionDict = {
 };
 
 export function getNotifWarningsInfo(data: Array<string>): Array<JSX.Element> {
+  type Category = keyof typeof categoryDescriptionDict;
   const result: Array<JSX.Element> = [];
   result.push(<p>⚠️ The following notification warnings were detected. ⚠️</p>);
 
-  Object.keys(categoryDescriptionDict).forEach((category: string) => {
-    const categoryWarnings = intersect(category, data);
+  Object.keys(categoryDescriptionDict).forEach((category: Category) => {
+    const categoryDict: Record<string, string> = warningDescriptionDict[category];
+    const categoryWarnings = Object.keys(categoryDict).filter((value) => -1 !== data.indexOf(value.toString()));
     if (categoryWarnings && categoryWarnings.length > 0) {
-      const warningList: Array<JSX.Element> = categoryWarnings.map((w: string) => {
-        return (<li key={w}>{w}: {warningDescriptionDict[category][w]}</li>);
+      const warningList: Array<JSX.Element> = categoryWarnings.map((w) => {
+        return (<li key={w}>{w}: {categoryDict[w]}</li>);
       });
 
       result.push(<p><b>{category}</b></p>);
@@ -79,8 +81,4 @@ export function getNotifWarningsInfo(data: Array<string>): Array<JSX.Element> {
   });
 
   return result;
-}
-
-export function intersect(category: string, data: Array<string>): Array<string> {
-  return Object.keys(warningDescriptionDict[category]).filter((value) => -1 !== data.indexOf(value.toString()));
 }

--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -16,6 +16,7 @@ import { DateRangeInput } from '@blueprintjs/datetime';
 
 import { SleuthState } from '../state/sleuth';
 import { ipcRenderer } from 'electron';
+import { LogLevel } from '../../interfaces';
 
 export interface FilterProps {
   state: SleuthState;
@@ -81,28 +82,28 @@ export class Filter extends React.Component<FilterProps, Partial<FilterState>> {
       <Menu>
         <Menu.Item
           active={debug}
-          onClick={() => this.props.state.onFilterToggle('debug')}
+          onClick={() => this.props.state.onFilterToggle(LogLevel.debug)}
           icon='code'
           shouldDismissPopover={false}
           text='Debug'
         />
         <Menu.Item
           active={info}
-          onClick={() => this.props.state.onFilterToggle('info')}
+          onClick={() => this.props.state.onFilterToggle(LogLevel.info)}
           icon='info-sign'
           shouldDismissPopover={false}
           text='Info'
         />
         <Menu.Item
           active={warn}
-          onClick={() => this.props.state.onFilterToggle('warn')}
+          onClick={() => this.props.state.onFilterToggle(LogLevel.warn)}
           icon='warning-sign'
           shouldDismissPopover={false}
           text='Warning'
         />
         <Menu.Item
           active={error}
-          onClick={() => this.props.state.onFilterToggle('error')}
+          onClick={() => this.props.state.onFilterToggle(LogLevel.error)}
           icon='error'
           shouldDismissPopover={false}
           text='Error'

--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -24,22 +24,19 @@ export interface LogContentState {
 }
 
 @observer
-export class LogContent extends React.Component<
-  LogContentProps,
-  Partial<LogContentState>
-> {
+export class LogContent extends React.Component<LogContentProps, Partial<LogContentState>> {
   constructor(props: LogContentProps) {
     super(props);
 
     this.state = {
-      tableHeight: 600,
+      tableHeight: 600
     };
 
     this.resizeHandler = this.resizeHandler.bind(this);
   }
 
   public resizeHandler(height: number) {
-    if (height < 100 || height > window.innerHeight - 100) return;
+    if (height < 100 || height > (window.innerHeight - 100)) return;
     this.setState({ tableHeight: height });
   }
 
@@ -53,26 +50,18 @@ export class LogContent extends React.Component<
       showOnlySearchResults,
       searchIndex,
       dateRange,
-      selectedEntry,
+      selectedEntry
     } = this.props.state;
 
     if (!selectedLogFile) return null;
     const isLog = isLogFile(selectedLogFile);
-    const scrubber = (
-      <Scrubber
-        elementSelector='LogTableContainer'
-        onResizeHandler={this.resizeHandler}
-      />
-    );
+    const scrubber = <Scrubber elementSelector='LogTableContainer' onResizeHandler={this.resizeHandler} />;
 
     // In most cases, we're dealing with a log file
     if (isLog) {
       return (
         <div className='LogContent' style={{ fontFamily: getFontForCSS(font) }}>
-          <div
-            id='LogTableContainer'
-            style={{ height: this.state.tableHeight }}
-          >
+          <div id='LogTableContainer' style={{ height: this.state.tableHeight }}>
             <LogTable
               state={this.props.state}
               dateTimeFormat={dateTimeFormat}

--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -24,19 +24,22 @@ export interface LogContentState {
 }
 
 @observer
-export class LogContent extends React.Component<LogContentProps, Partial<LogContentState>> {
+export class LogContent extends React.Component<
+  LogContentProps,
+  Partial<LogContentState>
+> {
   constructor(props: LogContentProps) {
     super(props);
 
     this.state = {
-      tableHeight: 600
+      tableHeight: 600,
     };
 
     this.resizeHandler = this.resizeHandler.bind(this);
   }
 
   public resizeHandler(height: number) {
-    if (height < 100 || height > (window.innerHeight - 100)) return;
+    if (height < 100 || height > window.innerHeight - 100) return;
     this.setState({ tableHeight: height });
   }
 
@@ -45,23 +48,31 @@ export class LogContent extends React.Component<LogContentProps, Partial<LogCont
       selectedLogFile,
       levelFilter,
       search,
-      dateTimeFormat,
+      dateTimeFormat_v3: dateTimeFormat,
       font,
       showOnlySearchResults,
       searchIndex,
       dateRange,
-      selectedEntry
+      selectedEntry,
     } = this.props.state;
 
     if (!selectedLogFile) return null;
     const isLog = isLogFile(selectedLogFile);
-    const scrubber = <Scrubber elementSelector='LogTableContainer' onResizeHandler={this.resizeHandler} />;
+    const scrubber = (
+      <Scrubber
+        elementSelector='LogTableContainer'
+        onResizeHandler={this.resizeHandler}
+      />
+    );
 
     // In most cases, we're dealing with a log file
     if (isLog) {
       return (
         <div className='LogContent' style={{ fontFamily: getFontForCSS(font) }}>
-          <div id='LogTableContainer' style={{ height: this.state.tableHeight }}>
+          <div
+            id='LogTableContainer'
+            style={{ height: this.state.tableHeight }}
+          >
             <LogTable
               state={this.props.state}
               dateTimeFormat={dateTimeFormat}

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -341,8 +341,8 @@ export class LogTable extends React.Component<LogTableProps, Partial<LogTableSta
     filter = filter || this.props.levelFilter;
 
     if (!filter) return false;
-    const allEnabled = Object.keys(filter).every((k) => filter![k]);
-    const allDisabled = Object.keys(filter).every((k) => !filter![k]);
+    const allEnabled = Object.keys(filter).every((k: keyof LevelFilter) => filter![k]);
+    const allDisabled = Object.keys(filter).every((k: keyof LevelFilter) => !filter![k]);
 
     return !(allEnabled || allDisabled);
   }

--- a/src/renderer/components/log-time-view.tsx
+++ b/src/renderer/components/log-time-view.tsx
@@ -64,7 +64,7 @@ export class LogTimeView extends React.Component<LogTimeViewProps> {
     const { timeBucketedLogMetrics } = this.props.state;
     if (timeBucketedLogMetrics) {
       const buckedLogMetricsByTime = Object.entries<LogMetrics>(timeBucketedLogMetrics);
-      datasets = Object.keys(LogLevel).map((type) => {
+      datasets = Object.keys(LogLevel).map((type: LogLevel) => {
         return {
           label: type,
           data: buckedLogMetricsByTime.map(([time, buckets]) => ({

--- a/src/renderer/components/preferences.tsx
+++ b/src/renderer/components/preferences.tsx
@@ -1,39 +1,17 @@
 import { Select } from '@blueprintjs/select';
 import { ipcRenderer } from 'electron';
 import { observer } from 'mobx-react';
-import {
-  Overlay,
-  Classes,
-  FormGroup,
-  Button,
-  MenuItem,
-  Callout,
-  ControlGroup,
-  InputGroup,
-  RadioGroup,
-  Radio,
-  Checkbox,
-  Divider,
-} from '@blueprintjs/core';
+import { Overlay, Classes, FormGroup, Button, MenuItem, Callout, ControlGroup, InputGroup, RadioGroup, Radio, Checkbox, Divider } from '@blueprintjs/core';
 import { SleuthState } from '../state/sleuth';
 import classNames from 'classnames';
 import React from 'react';
 import autoBind from 'react-autobind';
-import { format as dateFormatter } from 'date-fns';
+import {format as dateFormatter} from 'date-fns';
 
 import { getSleuth } from '../sleuth';
 import { renderFontItem, filterFont, FONTS } from './preferences-font';
-import {
-  filterDateTime,
-  renderDateTimeItem,
-  DATE_TIME_FORMATS,
-} from './preferences-datetime';
-import {
-  renderEditorItem,
-  Editor,
-  EDITORS,
-  nameForCmd,
-} from './preferences-editor';
+import { filterDateTime, renderDateTimeItem, DATE_TIME_FORMATS } from './preferences-datetime';
+import { renderEditorItem, Editor, EDITORS, nameForCmd } from './preferences-editor';
 import { SORT_DIRECTION } from './log-table-constants';
 
 const packageInfo = require('../../../package.json');
@@ -51,10 +29,7 @@ export interface PreferencesProps {
 }
 
 @observer
-export class Preferences extends React.Component<
-  PreferencesProps,
-  Partial<PreferencesState>
-> {
+export class Preferences extends React.Component<PreferencesProps, Partial<PreferencesState>> {
   constructor(props: PreferencesProps) {
     super(props);
 
@@ -65,17 +40,9 @@ export class Preferences extends React.Component<
   }
 
   public render(): JSX.Element {
-    const {
-      dateTimeFormat_v3: dateTimeFormat,
-      defaultEditor,
-      font,
-    } = this.props.state;
+    const { dateTimeFormat_v3, defaultEditor, font } = this.props.state;
 
-    const classes = classNames(
-      Classes.CARD,
-      Classes.ELEVATION_4,
-      'Preferences'
-    );
+    const classes = classNames(Classes.CARD, Classes.ELEVATION_4, 'Preferences');
 
     return (
       <Overlay
@@ -87,8 +54,8 @@ export class Preferences extends React.Component<
           <h2>Preferences</h2>
           <Callout>
             You're running Sleuth {packageInfo.version} {getSleuth()} with
-            Electron {process.versions.electron} and Chrome{' '}
-            {process.versions.chrome}.
+            Electron {process.versions.electron} and
+            Chrome {process.versions.chrome}.
           </Callout>
           <Divider style={{ marginTop: '15px' }} />
           <FormGroup
@@ -121,10 +88,7 @@ export class Preferences extends React.Component<
               onItemSelect={this.onDateTimeSelect}
               popoverProps={{ minimal: true }}
             >
-              <Button
-                text={dateFormatter(1647029957123, dateTimeFormat)}
-                rightIcon='calendar'
-              />
+              <Button text={dateFormatter(1647029957123, dateTimeFormat_v3)} rightIcon='calendar' />
             </DateTimeSelect>
           </FormGroup>
           <Divider />
@@ -134,13 +98,8 @@ export class Preferences extends React.Component<
             helperText='Sort logs by oldest (ascending) or newest (descending)'
           >
             <RadioGroup
-              onChange={(event) =>
-                (this.props.state.defaultSort = event.currentTarget
-                  .value as SORT_DIRECTION)
-              }
-              selectedValue={
-                this.props.state.defaultSort || SORT_DIRECTION.DESC
-              }
+              onChange={(event) => (this.props.state.defaultSort = event.currentTarget.value as SORT_DIRECTION)}
+              selectedValue={this.props.state.defaultSort || SORT_DIRECTION.DESC}
               inline={true}
             >
               <Radio label='Ascending' value={SORT_DIRECTION.ASC} />
@@ -156,10 +115,7 @@ export class Preferences extends React.Component<
             <Checkbox
               checked={this.props.state.isOpenMostRecent}
               label='Enabled'
-              onChange={(event) =>
-                (this.props.state.isOpenMostRecent =
-                  event.currentTarget.checked)
-              }
+              onChange={(event) => (this.props.state.isOpenMostRecent = event.currentTarget.checked)}
             />
           </FormGroup>
           <Divider />
@@ -171,9 +127,7 @@ export class Preferences extends React.Component<
             <Checkbox
               checked={this.props.state.isSmartCopy}
               label='Enabled'
-              onChange={(event) =>
-                (this.props.state.isSmartCopy = event.currentTarget.checked)
-              }
+              onChange={(event) => (this.props.state.isSmartCopy = event.currentTarget.checked)}
             />
           </FormGroup>
           <Divider />
@@ -209,9 +163,7 @@ export class Preferences extends React.Component<
             <Checkbox
               checked={this.props.state.isMarkIcon}
               label='Enabled'
-              onChange={(event) =>
-                (this.props.state.isMarkIcon = event.currentTarget.checked)
-              }
+              onChange={(event) => (this.props.state.isMarkIcon = event.currentTarget.checked)}
             />
           </FormGroup>
         </div>

--- a/src/renderer/components/preferences.tsx
+++ b/src/renderer/components/preferences.tsx
@@ -1,17 +1,39 @@
 import { Select } from '@blueprintjs/select';
 import { ipcRenderer } from 'electron';
 import { observer } from 'mobx-react';
-import { Overlay, Classes, FormGroup, Button, MenuItem, Callout, ControlGroup, InputGroup, RadioGroup, Radio, Checkbox, Divider } from '@blueprintjs/core';
+import {
+  Overlay,
+  Classes,
+  FormGroup,
+  Button,
+  MenuItem,
+  Callout,
+  ControlGroup,
+  InputGroup,
+  RadioGroup,
+  Radio,
+  Checkbox,
+  Divider,
+} from '@blueprintjs/core';
 import { SleuthState } from '../state/sleuth';
 import classNames from 'classnames';
 import React from 'react';
 import autoBind from 'react-autobind';
-import {format as dateFormatter} from 'date-fns';
+import { format as dateFormatter } from 'date-fns';
 
 import { getSleuth } from '../sleuth';
 import { renderFontItem, filterFont, FONTS } from './preferences-font';
-import { filterDateTime, renderDateTimeItem, DATE_TIME_FORMATS } from './preferences-datetime';
-import { renderEditorItem, Editor, EDITORS, nameForCmd } from './preferences-editor';
+import {
+  filterDateTime,
+  renderDateTimeItem,
+  DATE_TIME_FORMATS,
+} from './preferences-datetime';
+import {
+  renderEditorItem,
+  Editor,
+  EDITORS,
+  nameForCmd,
+} from './preferences-editor';
 import { SORT_DIRECTION } from './log-table-constants';
 
 const packageInfo = require('../../../package.json');
@@ -29,7 +51,10 @@ export interface PreferencesProps {
 }
 
 @observer
-export class Preferences extends React.Component<PreferencesProps, Partial<PreferencesState>> {
+export class Preferences extends React.Component<
+  PreferencesProps,
+  Partial<PreferencesState>
+> {
   constructor(props: PreferencesProps) {
     super(props);
 
@@ -40,9 +65,17 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
   }
 
   public render(): JSX.Element {
-    const { dateTimeFormat, defaultEditor, font } = this.props.state;
+    const {
+      dateTimeFormat_v3: dateTimeFormat,
+      defaultEditor,
+      font,
+    } = this.props.state;
 
-    const classes = classNames(Classes.CARD, Classes.ELEVATION_4, 'Preferences');
+    const classes = classNames(
+      Classes.CARD,
+      Classes.ELEVATION_4,
+      'Preferences'
+    );
 
     return (
       <Overlay
@@ -54,8 +87,8 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
           <h2>Preferences</h2>
           <Callout>
             You're running Sleuth {packageInfo.version} {getSleuth()} with
-            Electron {process.versions.electron} and
-            Chrome {process.versions.chrome}.
+            Electron {process.versions.electron} and Chrome{' '}
+            {process.versions.chrome}.
           </Callout>
           <Divider style={{ marginTop: '15px' }} />
           <FormGroup
@@ -88,7 +121,10 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
               onItemSelect={this.onDateTimeSelect}
               popoverProps={{ minimal: true }}
             >
-              <Button text={dateFormatter(1647029957123, dateTimeFormat)} rightIcon='calendar' />
+              <Button
+                text={dateFormatter(1647029957123, dateTimeFormat)}
+                rightIcon='calendar'
+              />
             </DateTimeSelect>
           </FormGroup>
           <Divider />
@@ -98,8 +134,13 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
             helperText='Sort logs by oldest (ascending) or newest (descending)'
           >
             <RadioGroup
-              onChange={(event) => (this.props.state.defaultSort = event.currentTarget.value as SORT_DIRECTION)}
-              selectedValue={this.props.state.defaultSort || SORT_DIRECTION.DESC}
+              onChange={(event) =>
+                (this.props.state.defaultSort = event.currentTarget
+                  .value as SORT_DIRECTION)
+              }
+              selectedValue={
+                this.props.state.defaultSort || SORT_DIRECTION.DESC
+              }
               inline={true}
             >
               <Radio label='Ascending' value={SORT_DIRECTION.ASC} />
@@ -115,7 +156,10 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
             <Checkbox
               checked={this.props.state.isOpenMostRecent}
               label='Enabled'
-              onChange={(event) => (this.props.state.isOpenMostRecent = event.currentTarget.checked)}
+              onChange={(event) =>
+                (this.props.state.isOpenMostRecent =
+                  event.currentTarget.checked)
+              }
             />
           </FormGroup>
           <Divider />
@@ -127,7 +171,9 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
             <Checkbox
               checked={this.props.state.isSmartCopy}
               label='Enabled'
-              onChange={(event) => (this.props.state.isSmartCopy = event.currentTarget.checked)}
+              onChange={(event) =>
+                (this.props.state.isSmartCopy = event.currentTarget.checked)
+              }
             />
           </FormGroup>
           <Divider />
@@ -163,7 +209,9 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
             <Checkbox
               checked={this.props.state.isMarkIcon}
               label='Enabled'
-              onChange={(event) => (this.props.state.isMarkIcon = event.currentTarget.checked)}
+              onChange={(event) =>
+                (this.props.state.isMarkIcon = event.currentTarget.checked)
+              }
             />
           </FormGroup>
         </div>
@@ -190,6 +238,6 @@ export class Preferences extends React.Component<PreferencesProps, Partial<Prefe
   }
 
   private onDateTimeSelect(format: string) {
-    this.props.state.dateTimeFormat = format;
+    this.props.state.dateTimeFormat_v3 = format;
   }
 }

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -140,16 +140,16 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
 
     if (!processedLogFiles) return {};
 
-    Sidebar.setChildNodes(NODE_ID.STATE, state, processedLogFiles.state.map((file) => Sidebar.getStateFileNode(file as any, props)));
+    Sidebar.setChildNodes(NODE_ID.STATE, state, processedLogFiles.state.map((file) => Sidebar.getStateFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.BROWSER, state, processedLogFiles.browser.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.RENDERER, state, processedLogFiles.renderer.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.PRELOAD, state, processedLogFiles.preload.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.WEBAPP, state, processedLogFiles.webapp.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.CALLS, state, processedLogFiles.call.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.INSTALLER, state, processedLogFiles.installer.map((file) => Sidebar.getInstallerFileNode(file, props)));
-    Sidebar.setChildNodes(NODE_ID.NETWORK, state, processedLogFiles.netlog.map((file, i) => Sidebar.getNetlogFileNode(file as any, props, i)));
+    Sidebar.setChildNodes(NODE_ID.NETWORK, state, processedLogFiles.netlog.map((file, i) => Sidebar.getNetlogFileNode(file, props, i)));
     Sidebar.setChildNodes(NODE_ID.MOBILE, state, processedLogFiles.mobile.map((file) => Sidebar.getFileNode(file, props)));
-    Sidebar.setChildNodes(NODE_ID.TRACE, state, processedLogFiles.trace.map((file) => Sidebar.getStateFileNode(file as any, props)));
+    Sidebar.setChildNodes(NODE_ID.TRACE, state, processedLogFiles.trace.map((file) => Sidebar.getStateFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.CHROMIUM, state, processedLogFiles.chromium.map((file) => Sidebar.getFileNode(file, props)));
 
     return { nodes: state.nodes };

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -140,16 +140,16 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
 
     if (!processedLogFiles) return {};
 
-    Sidebar.setChildNodes(NODE_ID.STATE, state, processedLogFiles.state.map((file) => Sidebar.getStateFileNode(file, props)));
+    Sidebar.setChildNodes(NODE_ID.STATE, state, processedLogFiles.state.map((file) => Sidebar.getStateFileNode(file as any, props)));
     Sidebar.setChildNodes(NODE_ID.BROWSER, state, processedLogFiles.browser.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.RENDERER, state, processedLogFiles.renderer.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.PRELOAD, state, processedLogFiles.preload.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.WEBAPP, state, processedLogFiles.webapp.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.CALLS, state, processedLogFiles.call.map((file) => Sidebar.getFileNode(file, props)));
     Sidebar.setChildNodes(NODE_ID.INSTALLER, state, processedLogFiles.installer.map((file) => Sidebar.getInstallerFileNode(file, props)));
-    Sidebar.setChildNodes(NODE_ID.NETWORK, state, processedLogFiles.netlog.map((file, i) => Sidebar.getNetlogFileNode(file, props, i)));
+    Sidebar.setChildNodes(NODE_ID.NETWORK, state, processedLogFiles.netlog.map((file, i) => Sidebar.getNetlogFileNode(file as any, props, i)));
     Sidebar.setChildNodes(NODE_ID.MOBILE, state, processedLogFiles.mobile.map((file) => Sidebar.getFileNode(file, props)));
-    Sidebar.setChildNodes(NODE_ID.TRACE, state, processedLogFiles.trace.map((file) => Sidebar.getStateFileNode(file, props)));
+    Sidebar.setChildNodes(NODE_ID.TRACE, state, processedLogFiles.trace.map((file) => Sidebar.getStateFileNode(file as any, props)));
     Sidebar.setChildNodes(NODE_ID.CHROMIUM, state, processedLogFiles.chromium.map((file) => Sidebar.getFileNode(file, props)));
 
     return { nodes: state.nodes };

--- a/src/renderer/components/spotlight.tsx
+++ b/src/renderer/components/spotlight.tsx
@@ -7,7 +7,7 @@ import { MenuItem } from '@blueprintjs/core';
 import { ipcRenderer } from 'electron';
 
 import { SleuthState } from '../state/sleuth';
-import { ProcessedLogFile, UnzippedFile } from '../../interfaces';
+import { ProcessedLogFile, ProcessedLogFiles, UnzippedFile } from '../../interfaces';
 import { isProcessedLogFile } from '../../utils/is-logfile';
 import { highlightText } from '../../utils/highlight-text';
 
@@ -86,10 +86,10 @@ export class Spotlight extends React.Component<SpotlightProps, Partial<Spotlight
     const { suggestions } = this.props.state;
     const { processedLogFiles } = this.props.state;
 
-    const spotSuggestions: Array<SpotlightItem> = Object.keys(suggestions)
-      .map((filePath) => ({
+    const spotSuggestions: Array<SpotlightItem> = suggestions
+      .map(({filePath, age}) => ({
         text: path.basename(filePath),
-        label: `${suggestions[filePath].age} old`,
+        label: `${age} old`,
         icon: filePath.endsWith('zip') ? 'compressed' : 'folder-open',
         click: () => {
           this.props.state.openFile(filePath);
@@ -98,30 +98,32 @@ export class Spotlight extends React.Component<SpotlightProps, Partial<Spotlight
 
     const logFileSuggestions: Array<SpotlightItem> = [];
 
-    Object.keys(processedLogFiles || {}).forEach((key) => {
-      const keyFiles: Array<ProcessedLogFile | UnzippedFile> = processedLogFiles![key];
-      keyFiles.forEach((logFile) => {
-        if (isProcessedLogFile(logFile)) {
-          logFileSuggestions.push({
-            text: logFile.logFile.fileName,
-            label: `${logFile.logEntries.length} entries`,
-            icon: 'document',
-            click: () => {
-              this.props.state.selectLogFile(logFile);
-            }
-          });
-        } else {
-          logFileSuggestions.push({
-            text: logFile.fileName,
-            label: `State`,
-            icon: 'cog',
-            click: () => {
-              this.props.state.selectLogFile(logFile);
-            }
-          });
-        }
+    if (processedLogFiles) {
+      Object.keys(processedLogFiles).forEach((key: keyof ProcessedLogFiles) => {
+        const keyFiles: Array<ProcessedLogFile | UnzippedFile> = processedLogFiles[key];
+        keyFiles.forEach((logFile) => {
+          if (isProcessedLogFile(logFile)) {
+            logFileSuggestions.push({
+              text: logFile.logFile.fileName,
+              label: `${logFile.logEntries.length} entries`,
+              icon: 'document',
+              click: () => {
+                this.props.state.selectLogFile(logFile);
+              }
+            });
+          } else {
+            logFileSuggestions.push({
+              text: logFile.fileName,
+              label: `State`,
+              icon: 'cog',
+              click: () => {
+                this.props.state.selectLogFile(logFile);
+              }
+            });
+          }
+        });
       });
-    });
+    }
 
     const appSuggestions = [
       {

--- a/src/renderer/processor/performance.ts
+++ b/src/renderer/processor/performance.ts
@@ -1,4 +1,4 @@
-import { ProcessorPerformanceInfo, LogType, ALL_LOG_TYPES } from '../../interfaces';
+import { ProcessorPerformanceInfo, ALL_LOG_TYPES, SelectableLogType, LogType } from '../../interfaces';
 
 let logBuffer: Array<ProcessorPerformanceInfo> = [];
 
@@ -9,7 +9,7 @@ export function logPerformance(input: ProcessorPerformanceInfo) {
   });
 }
 
-export function combineResultsForType(type: LogType): ProcessorPerformanceInfo {
+export function combineResultsForType(type: SelectableLogType): ProcessorPerformanceInfo {
   return logBuffer.reduce((prev, curr) => {
     if (type !== LogType.ALL && curr.type !== type) return prev;
 

--- a/src/renderer/processor/performance.ts
+++ b/src/renderer/processor/performance.ts
@@ -1,4 +1,4 @@
-import { ProcessorPerformanceInfo, ALL_LOG_TYPES, SelectableLogType, LogType } from '../../interfaces';
+import { ProcessorPerformanceInfo, SelectableLogType, LogType, LOG_TYPES_TO_PROCESS } from '../../interfaces';
 
 let logBuffer: Array<ProcessorPerformanceInfo> = [];
 
@@ -31,7 +31,7 @@ export function combineResultsForType(type: SelectableLogType): ProcessorPerform
 export function flushLogPerformance() {
   const summary: Array<ProcessorPerformanceInfo> = [];
 
-  for (const logType of ALL_LOG_TYPES) {
+  for (const logType of LOG_TYPES_TO_PROCESS) {
     summary.push(combineResultsForType(logType));
   }
 

--- a/src/renderer/state/bookmarks.ts
+++ b/src/renderer/state/bookmarks.ts
@@ -194,7 +194,7 @@ export function deserializeBookmark(state: SleuthState, serialized: SerializedBo
 
     Object.keys(state.processedLogFiles).some((key: keyof ProcessedLogFiles) => {
       const files = state.processedLogFiles![key];
-      const foundFile = files.find((file: ProcessedLogFile) => file.id === serialized.logFile.id);
+      const foundFile = (files as Array<ProcessedLogFile>).find((file: ProcessedLogFile) => file.id === serialized.logFile.id);
 
       if (foundFile) {
         logFile = foundFile;

--- a/src/renderer/state/bookmarks.ts
+++ b/src/renderer/state/bookmarks.ts
@@ -1,4 +1,4 @@
-import { Bookmark, SerializedBookmark, ProcessedLogFile, LogFile, LogEntry, CompressedBookmark } from '../../interfaces';
+import { Bookmark, SerializedBookmark, ProcessedLogFile, LogFile, LogEntry, CompressedBookmark, ProcessedLogFiles, MergedLogFiles } from '../../interfaces';
 import { isTool, isUnzippedFile } from '../../utils/is-logfile';
 import { SleuthState } from './sleuth';
 
@@ -192,7 +192,7 @@ export function deserializeBookmark(state: SleuthState, serialized: SerializedBo
   if (serialized.logFile.type === 'ProcessedLogFile') {
     if (!state.processedLogFiles) return;
 
-    Object.keys(state.processedLogFiles).some((key) => {
+    Object.keys(state.processedLogFiles).some((key: keyof ProcessedLogFiles) => {
       const files = state.processedLogFiles![key];
       const foundFile = files.find((file: ProcessedLogFile) => file.id === serialized.logFile.id);
 
@@ -206,7 +206,7 @@ export function deserializeBookmark(state: SleuthState, serialized: SerializedBo
   } else if (serialized.logFile.type === 'MergedLogFile') {
       if (!state.mergedLogFiles) return;
 
-    Object.keys(state.mergedLogFiles).some((key) => {
+    Object.keys(state.mergedLogFiles).some((key: keyof MergedLogFiles) => {
       const file = state.mergedLogFiles![key];
 
       if (file.id === serialized.logFile.id) {
@@ -262,7 +262,7 @@ export function compressBookmark(input: SerializedBookmark): CompressedBookmark 
  * @returns {SerializedBookmark}
  */
 export function decompressBookmark(input: CompressedBookmark): SerializedBookmark {
-  const logFileType = Object.keys(CompressedLogTypes).find((key) => {
+  const logFileType = Object.keys(CompressedLogTypes).find((key: keyof typeof CompressedLogTypes) => {
     return input[3] === CompressedLogTypes[key];
   }) as 'MergedLogFile' | 'ProcessedLogFile';
 

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -14,7 +14,6 @@ import {
   MergedLogFile,
   ProcessedLogFile,
   DateRange,
-  Suggestions,
   Tool,
   Bookmark,
   MergedLogFiles,
@@ -22,7 +21,11 @@ import {
   SelectableLogFile,
   ProcessedLogFiles,
   SerializedBookmark,
-  TimeBucketedLogMetrics
+  TimeBucketedLogMetrics,
+  LogLevel,
+  LogType,
+  KnownLogType,
+  Suggestion
 } from '../../interfaces';
 import { getInitialTimeViewRange, getTimeBuckedLogMetrics } from './time-view';
 import { rehydrateBookmarks, importBookmarks } from './bookmarks';
@@ -33,8 +36,9 @@ import { setupTouchBarAutoruns } from './touchbar';
 import { RendererDescription } from '../processor/trace';
 
 const debug = require('debug')('sleuth:state');
+
 export const defaults = {
-  dateTimeFormat: 'HH:mm:ss (dd/MM)',
+  dateTimeFormat_v3: 'HH:mm:ss (dd/MM)',
   defaultEditor: 'code --goto {filepath}:{line}',
   font: process.platform === 'darwin' ? 'San Francisco' : 'Segoe UI',
   isDarkMode: true,
@@ -80,7 +84,7 @@ export class SleuthState {
   @observable public showOnlySearchResults: boolean | undefined;
 
   // ** Various "what are we showing" properties **
-  @observable public suggestions: Suggestions = [];
+  @observable public suggestions: Array<Suggestion> = [];
   @observable public webAppLogsWarningDismissed: boolean = false;
   @observable public opened: number = 0;
   @observable public dateRange: DateRange = { from: null, to: null };
@@ -94,15 +98,15 @@ export class SleuthState {
   @observable public rendererThreads: Array<RendererDescription> | undefined;
 
   // ** Settings **
-  @observable public isDarkMode: boolean = !!this.retrieve('isDarkMode', true);
-  @observable public isOpenMostRecent: boolean = !!this.retrieve<boolean>('isOpenMostRecent', true);
-  @observable public dateTimeFormat: string
-    = testDateTimeFormat(this.retrieve<string>('dateTimeFormat_v3', false)!, defaults.dateTimeFormat);
+  @observable public isDarkMode = !!this.retrieve('isDarkMode', true);
+  @observable public isOpenMostRecent = !!this.retrieve<boolean>('isOpenMostRecent', true);
+  @observable public dateTimeFormat_v3: string
+    = testDateTimeFormat(this.retrieve<string>('dateTimeFormat_v3', false)!, defaults.dateTimeFormat_v3);
   @observable public font: string = this.retrieve<string>('font', false)!;
   @observable public defaultEditor: string = this.retrieve<string>('defaultEditor', false)!;
   @observable public defaultSort: SORT_DIRECTION = this.retrieve('defaultSort', false) as SORT_DIRECTION || SORT_DIRECTION.DESC;
-  @observable public isMarkIcon: boolean = !!this.retrieve('isMarkIcon', true);
-  @observable public isSmartCopy: boolean = !!this.retrieve('isSmartCopy', true);
+  @observable public isMarkIcon = !!this.retrieve('isMarkIcon', true);
+  @observable public isSmartCopy = !!this.retrieve('isSmartCopy', true);
 
   // ** Giant non-observable arrays **
   public mergedLogFiles?: MergedLogFiles;
@@ -118,7 +122,7 @@ export class SleuthState {
     this.getSuggestions();
 
     // Setup autoruns
-    autorun(() => this.save('dateTimeFormat_v3', this.dateTimeFormat));
+    autorun(() => this.save('dateTimeFormat_v3', this.dateTimeFormat_v3));
     autorun(() => this.save('font', this.font));
     autorun(() => this.save('isOpenMostRecent', this.isOpenMostRecent));
     autorun(() => this.save('isSmartCopy', this.isSmartCopy));
@@ -178,7 +182,7 @@ export class SleuthState {
     ipcRenderer.on(STATE_IPC.COPY, () => copy(this));
     ipcRenderer.on(STATE_IPC.RESET, () => this.reset(true));
     ipcRenderer.on(STATE_IPC.TOGGLE_DARKMODE, () => this.toggleDarkMode());
-    ipcRenderer.on(STATE_IPC.TOGGLE_FILTER, (_event, level: string) => {
+    ipcRenderer.on(STATE_IPC.TOGGLE_FILTER, (_event, level: LogLevel) => {
       this.onFilterToggle(level);
     });
 
@@ -301,32 +305,28 @@ export class SleuthState {
   /**
    * Select a log file. This is a more complex operation than one might think -
    * mostly because we might need to create a merged file on-the-fly.
-   *
-   * @param {ProcessedLogFile} logFile
-   * @param {string} [logType]
    */
   @action
-  public selectLogFile(logFile: ProcessedLogFile | UnzippedFile | null, logType?: string): void {
+  public selectLogFile(logFile: ProcessedLogFile | UnzippedFile | null, logType?: KnownLogType | Tool): void {
     this.selectedEntry = undefined;
     this.selectedRangeEntries = undefined;
     this.selectedRangeIndex = undefined;
     this.selectedIndex = undefined;
     this.customTimeViewRange = undefined;
 
-    if (!logFile && logType) {
-      debug(`Selecting log type ${logType}`);
-
-      // If our "logtype" is actually a tool (like Cache), we'll set it
-      if (logType in Tool) {
-        this.selectedLogFile = logType as Tool;
-      } else if (this.mergedLogFiles && this.mergedLogFiles[logType]) {
-        this.selectedLogFile = this.mergedLogFiles[logType];
-      }
-    } else if (logFile) {
-      const name = isProcessedLogFile(logFile) ? logFile.logType : logFile.fileName;
+    // FIXME: this logic should be refactored so that Tools aren't passed as a "logType"
+    if (logFile) {
+      const name = isProcessedLogFile(logFile)
+        ? logFile.logType
+        : logFile.fileName;
       debug(`Selecting log file ${name}`);
 
       this.selectedLogFile = logFile;
+    } else if (logType && logType in LogType) {
+      debug(`Selecting log type ${logType}`);
+      this.mergedLogFiles![logType as KnownLogType];
+    } else if (logType && logType in Tool) {
+      this.selectedLogFile = (logType as Tool);
     }
   }
 
@@ -337,7 +337,7 @@ export class SleuthState {
    * @memberof SleuthState
    */
   @action
-  public onFilterToggle(level: string) {
+  public onFilterToggle(level: LogLevel) {
     if (this.levelFilter![level] !== undefined) {
       const filter = {...this.levelFilter};
       filter[level] = !filter[level];
@@ -391,7 +391,7 @@ export class SleuthState {
    * @returns {(T | string | null)}
    */
   private retrieve<T>(
-    key: string, parse: boolean
+    key: keyof SleuthState, parse: boolean
   ): T | string | null {
     let value: T | string | null = localStorage.getItem(key);
 
@@ -399,8 +399,8 @@ export class SleuthState {
       value = JSON.parse(value || 'null') as T;
     }
 
-    if (value === null && defaults[key]) {
-      return defaults[key];
+    if (value === null && (defaults as Partial<SleuthState>)[key]) {
+      return (defaults as Partial<SleuthState>)[key] as unknown as T;
     }
 
     return value;

--- a/src/renderer/suggestions.ts
+++ b/src/renderer/suggestions.ts
@@ -3,13 +3,13 @@ import fs from 'fs-extra';
 import path from 'path';
 import { formatDistanceToNow } from 'date-fns';
 
-import { Suggestions, Suggestion } from '../interfaces';
+import { Suggestion } from '../interfaces';
 import { getPath, showMessageBox } from './ipc';
 
 const debug = require('debug')('sleuth:suggestions');
 
-export async function getItemsInSuggestionFolders(): Promise<Suggestions> {
- const suggestionsArr: Array<Suggestion> = [];
+export async function getItemsInSuggestionFolders(): Promise<Array<Suggestion>> {
+ const suggestionsArr = [];
 
   // We'll get suggestions from the downloads folder and
   // the desktop

--- a/test/__mocks__/processed-log-file.ts
+++ b/test/__mocks__/processed-log-file.ts
@@ -1,4 +1,4 @@
-import { ProcessedLogFile, LogType } from '../../src/interfaces';
+import { ProcessedLogFile, LogType, LogLevel } from '../../src/interfaces';
 
 export const mockBrowserFile1: ProcessedLogFile = {
   id: '123',
@@ -6,7 +6,7 @@ export const mockBrowserFile1: ProcessedLogFile = {
   logEntries: [
     {
       index: 0,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Hi!',
       momentValue: 1488837185497,
@@ -15,7 +15,7 @@ export const mockBrowserFile1: ProcessedLogFile = {
       sourceFile: 'test-file'
     }, {
       index: 1,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Yo!',
       momentValue: 1488837201751,
@@ -24,7 +24,7 @@ export const mockBrowserFile1: ProcessedLogFile = {
       sourceFile: 'test-file'
     }, {
       index: 2,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Hey!',
       momentValue: 1488837270030,
@@ -52,7 +52,7 @@ export const mockBrowserFile2: ProcessedLogFile = {
   logEntries: [
     {
       index: 0,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Hi!',
       momentValue: 1488837228089,
@@ -61,7 +61,7 @@ export const mockBrowserFile2: ProcessedLogFile = {
       sourceFile: 'test-file',
     }, {
       index: 1,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Yo!',
       momentValue: 1488837285150,
@@ -70,7 +70,7 @@ export const mockBrowserFile2: ProcessedLogFile = {
       sourceFile: 'test-file',
     }, {
       index: 2,
-      level: 'info',
+      level: LogLevel.info,
       logType: LogType.BROWSER,
       message: 'Hey!',
       momentValue: 1488837294254,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     ],
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noImplicitThis": true,
@@ -36,9 +35,5 @@
   ],
   "exclude": [
     "node_modules"
-  ],
-  "formatCodeOptions": {
-    "indentSize": 2,
-    "tabSize": 2
-  }
+  ]
 }


### PR DESCRIPTION
This is a prerequisite for #65.

Disabling a bad `tsconfig.json` setting so that we have an easier time migrating to ESLint. This changes up a lot of the LogFile types, which honestly need even more cleanup after this.