### PR TITLE
feat: enabled single date filtering

### DIFF
--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -138,7 +138,7 @@ export class Filter extends React.Component<FilterProps, Partial<FilterState>> {
           <NavbarDivider />
           <DateRangeInput
             allowSingleDayRange={true}
-            timePickerProps={{precision: TimePrecision.MINUTE, showArrowButtons: false}}
+            timePickerProps={{precision: TimePrecision.MINUTE, showArrowButtons: true}}
             formatDate={(date) => date.toLocaleString()}
             onChange={this.onDateRangeChange}
             parseDate={(str) => new Date(str)}

--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -12,7 +12,7 @@ import {
   Menu,
   Position
 } from '@blueprintjs/core';
-import { DateRangeInput } from '@blueprintjs/datetime';
+import { DateRangeInput, TimePrecision } from '@blueprintjs/datetime';
 
 import { SleuthState } from '../state/sleuth';
 import { ipcRenderer } from 'electron';
@@ -137,6 +137,8 @@ export class Filter extends React.Component<FilterProps, Partial<FilterState>> {
         <NavbarGroup className='SearchGroup'>
           <NavbarDivider />
           <DateRangeInput
+            allowSingleDayRange={true}
+            timePickerProps={{precision: TimePrecision.MINUTE, showArrowButtons: false}}
             formatDate={(date) => date.toLocaleString()}
             onChange={this.onDateRangeChange}
             parseDate={(str) => new Date(str)}


### PR DESCRIPTION
Fixes #72 by adding props to Date Range input component from Blueprint
Importance: Gives user option to select a single date and the time to filter by (see below).

**Before Change:**

https://github.com/tinyspeck/sleuth/assets/52749324/b16287a1-855a-4844-9edb-1ee8378b889d

**After Change:**

https://github.com/tinyspeck/sleuth/assets/52749324/f7730c2b-ee53-4a22-b026-be559f41c808


Notes:
- Time is in 24 hour format


