### PR TITLE
feat: Minimize/Maximize on Double Click (MacOS)

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -1,0 +1,7 @@
+export enum IpcEvents {
+	CLICK_TITLEBAR_MAC = 'CLICK_TITLEBAR_MAC'
+}
+
+export const ipcMainEvents = [
+	IpcEvents.CLICK_TITLEBAR_MAC
+]

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -1,7 +1,3 @@
 export enum IpcEvents {
   CLICK_TITLEBAR_MAC = 'CLICK_TITLEBAR_MAC'
 }
-
-export const ipcMainEvents = [
-  IpcEvents.CLICK_TITLEBAR_MAC
-];

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -1,7 +1,7 @@
 export enum IpcEvents {
-	CLICK_TITLEBAR_MAC = 'CLICK_TITLEBAR_MAC'
+  CLICK_TITLEBAR_MAC = 'CLICK_TITLEBAR_MAC'
 }
 
 export const ipcMainEvents = [
-	IpcEvents.CLICK_TITLEBAR_MAC
-]
+  IpcEvents.CLICK_TITLEBAR_MAC
+];

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -87,7 +87,7 @@ export class IpcManager {
 
   private setupTitleBarClickMac() {
     // if it is not a Mac then it will do nothing
-    if (process.platform != 'darwin'){
+    if (process.platform !== 'darwin'){
       return;
     }
 
@@ -110,9 +110,9 @@ export class IpcManager {
         }
       }
       } catch (error){
-        console.error("Couldnt minimize or maximize", error)
+        console.error('Couldnt minimize or maximize', error);
       }
-    })
+    });
   }
 
   private setupMessageBoxHandler() {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,10 +1,11 @@
-import { shell, BrowserWindow, app, ipcMain, dialog } from 'electron';
+import { shell, BrowserWindow, app, ipcMain, dialog, systemPreferences, IpcMainEvent } from 'electron';
 import * as path from 'path';
 
 import { createWindow } from './windows';
 import { settingsFileManager } from './settings';
 import { changeIcon } from './app-icon';
 import { ICON_NAMES } from '../shared-constants';
+import { IpcEvents } from '../ipc-events';
 
 export class IpcManager {
   constructor() {
@@ -20,6 +21,7 @@ export class IpcManager {
     this.setupCopy();
     this.setupQuit();
     this.setupOpenRecent();
+    this.setupTitleBarClickMac();
   }
 
   public openFile(pathName: string) {
@@ -81,6 +83,36 @@ export class IpcManager {
         console.warn(`Could not show window`, error);
       }
     });
+  }
+
+  private setupTitleBarClickMac() {
+    // if it is not a Mac then it will do nothing
+    if (process.platform != 'darwin'){
+      return;
+    }
+
+    ipcMain.on(IpcEvents.CLICK_TITLEBAR_MAC, (event: IpcMainEvent) => {
+      try{
+      const doubleClickAction = systemPreferences.getUserDefault(
+        'AppleActionOnDoubleClick',
+        'string'
+      );
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (win) {
+        if (doubleClickAction === 'Minimize') {
+          win.minimize();
+        } else if (doubleClickAction === 'Maximize') {
+          if (!win.isMaximized()){
+            win.maximize();
+          } else {
+            win.unmaximize();
+          }
+        }
+      }
+      } catch (error){
+        console.error("Couldnt minimize or maximize", error)
+      }
+    })
   }
 
   private setupMessageBoxHandler() {

--- a/src/renderer/components/mac-titlebar.tsx
+++ b/src/renderer/components/mac-titlebar.tsx
@@ -13,7 +13,7 @@ export class MacTitlebar extends React.Component<TitlebarProps> {
   }
 
   private handleDoubleClick = () => {
-      sendDoubleClick()
+      sendDoubleClick();
   }
 
   render () {

--- a/src/renderer/components/mac-titlebar.tsx
+++ b/src/renderer/components/mac-titlebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SleuthState } from '../state/sleuth';
 import { getWindowTitle } from '../../utils/get-window-title';
+import { sendDoubleClick } from '../ipc';
 
 interface TitlebarProps {
   state: SleuthState;
@@ -11,8 +12,12 @@ export class MacTitlebar extends React.Component<TitlebarProps> {
     super(props);
   }
 
+  private handleDoubleClick = () => {
+      sendDoubleClick()
+  }
+
   render () {
     const { source } = this.props.state;
-    return <div className='MacTitlebar'><span>{getWindowTitle(source)}</span></div>;
+    return <div className='MacTitlebar' onDoubleClick={this.handleDoubleClick}><span>{getWindowTitle(source)}</span></div>;
   }
 }

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -22,7 +22,7 @@ export function sendWindowReady() {
 }
 
 export function sendDoubleClick(){
-  ipcRenderer.send(IpcEvents.CLICK_TITLEBAR_MAC)
+  ipcRenderer.send(IpcEvents.CLICK_TITLEBAR_MAC);
 }
 
 export function showOpenDialog(): Promise<Electron.OpenDialogReturnValue> {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron';
 import { ICON_NAMES } from '../shared-constants';
+import { IpcEvents } from '../ipc-events';
 
 // This file handles sending IPC events. Other classes might
 // listen to IPC events.
@@ -18,6 +19,10 @@ export function getUserAgent(): Promise<string> {
 
 export function sendWindowReady() {
   ipcRenderer.send('window-ready');
+}
+
+export function sendDoubleClick(){
+  ipcRenderer.send(IpcEvents.CLICK_TITLEBAR_MAC)
 }
 
 export function showOpenDialog(): Promise<Electron.OpenDialogReturnValue> {


### PR DESCRIPTION
Fixes #74 by allowing Mac users to minimize/maximize their Sleuth window by double clicking the titlebar.
**Importance:** Matches convention of other Mac applications (VSCode, Electron Fiddle, etc) that users may use.

GIF of Change in Action:

https://github.com/tinyspeck/sleuth/assets/52749324/601564fb-61ba-4503-b1d1-0678fd77928d

