### PR TITLE
fix: Disable remote module

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -80,7 +80,6 @@ export async function createWindow(): Promise<BrowserWindow> {
       webviewTag: false,
       nodeIntegration: true,
       contextIsolation: false,
-      enableRemoteModule: true
     }
   };
   console.log(`Windows: Creating window with options`, options);

--- a/test/__mocks__/electron.ts
+++ b/test/__mocks__/electron.ts
@@ -19,8 +19,5 @@ const shell = {
   trashItem: jest.fn()
 };
 
-const remote = {
-  app
-};
 
-module.exports = { ipcRenderer, remote, shell };
+module.exports = { ipcRenderer, shell };

--- a/test/__mocks__/electron.ts
+++ b/test/__mocks__/electron.ts
@@ -1,18 +1,6 @@
-import path from 'path';
-
 const ipcRenderer = {
   send: jest.fn(),
   invoke: jest.fn(),
-};
-
-const app = {
-  getPath(target: string) {
-    if (target === 'downloads') {
-      return path.join(__dirname, '../static/');
-    }
-
-    return __dirname;
-  }
 };
 
 const shell = {


### PR DESCRIPTION
Fixes #67 by disabling Electron remote module in WebPreferences and removing all instances of remote