### PR TITLE
feat: display number of results

### DIFF
--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -14,6 +14,7 @@ import { NetLogView } from './net-log-view';
 import { ToolView } from './tool-view';
 import { LogTimeView } from './log-time-view';
 import { DevtoolsView } from './devtools-view';
+import NumberResults from './number-results';
 
 export interface LogContentProps {
   state: SleuthState;
@@ -21,18 +22,26 @@ export interface LogContentProps {
 
 export interface LogContentState {
   tableHeight: number;
+  numberResults: number;
 }
 
 @observer
 export class LogContent extends React.Component<LogContentProps, Partial<LogContentState>> {
+
   constructor(props: LogContentProps) {
     super(props);
 
     this.state = {
-      tableHeight: 600
+      tableHeight: 600,
+      numberResults: 0,
     };
 
     this.resizeHandler = this.resizeHandler.bind(this);
+  }
+
+  // function to lift state up from logtable (where sortedlist is located) and take the length of list of logs and update this state's numberResults to display
+  public updateNumberResults = (results: number): void => {
+    this.setState({numberResults: results});
   }
 
   public resizeHandler(height: number) {
@@ -50,7 +59,7 @@ export class LogContent extends React.Component<LogContentProps, Partial<LogCont
       showOnlySearchResults,
       searchIndex,
       dateRange,
-      selectedEntry
+      selectedEntry,
     } = this.props.state;
 
     if (!selectedLogFile) return null;
@@ -61,6 +70,7 @@ export class LogContent extends React.Component<LogContentProps, Partial<LogCont
     if (isLog) {
       return (
         <div className='LogContent' style={{ fontFamily: getFontForCSS(font) }}>
+          <NumberResults numberOfResults={this.state.numberResults} />
           <div id='LogTableContainer' style={{ height: this.state.tableHeight }}>
             <LogTable
               state={this.props.state}
@@ -72,6 +82,7 @@ export class LogContent extends React.Component<LogContentProps, Partial<LogCont
               searchIndex={searchIndex}
               dateRange={dateRange}
               selectedEntry={selectedEntry}
+              resultFunction={this.updateNumberResults}
             />
           </div>
           {scrubber}

--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -27,7 +27,6 @@ export interface LogContentState {
 
 @observer
 export class LogContent extends React.Component<LogContentProps, Partial<LogContentState>> {
-
   constructor(props: LogContentProps) {
     super(props);
 

--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -21,12 +21,12 @@ export interface LogContentProps {
 }
 
 export interface LogContentState {
-  tableHeight: number;
+  tableHeight?: number;
   numberResults: number;
 }
 
 @observer
-export class LogContent extends React.Component<LogContentProps, Partial<LogContentState>> {
+export class LogContent extends React.Component<LogContentProps, LogContentState> {
   constructor(props: LogContentProps) {
     super(props);
 

--- a/src/renderer/components/log-table-constants.ts
+++ b/src/renderer/components/log-table-constants.ts
@@ -24,6 +24,7 @@ export interface LogTableProps {
   searchIndex: number;
   dateRange?: DateRange;
   selectedEntry?: LogEntry;
+  resultFunction: (results: number) => void;
 }
 
 export interface LogTableState {

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -574,7 +574,7 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
     const { sortedList, selectedIndex, searchList, ignoreSearchIndex, scrollToSelection } = this.state;
     const { searchIndex, resultFunction } = this.props;
 
-    if(sortedList){
+    if(Array.isArray(sortedList)){
       resultFunction(sortedList.length)
     }
 

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -572,7 +572,11 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
    */
   private renderTable(options: Size): JSX.Element {
     const { sortedList, selectedIndex, searchList, ignoreSearchIndex, scrollToSelection } = this.state;
-    const { searchIndex } = this.props;
+    const { searchIndex, resultFunction } = this.props;
+
+    if(sortedList){
+      resultFunction(sortedList.length)
+    }
 
     const tableOptions: TableProps = {
       ...options,

--- a/src/renderer/components/number-results.tsx
+++ b/src/renderer/components/number-results.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+export interface NumberResultsProps {
+	numberOfResults: number | undefined;
+}
+
+export default function NumberResults(props: NumberResultsProps){
+	const conversion = (numberToConvert: number | undefined): string => {
+		if(numberToConvert){
+			return numberToConvert.toLocaleString();
+		}else{
+			return '0'
+		}
+	}
+
+	return (
+		<div id="numberResultsContainer">
+			<p id="numberResults">{conversion(props.numberOfResults)}</p>
+			<p id="resultTag">{props.numberOfResults === 1 ? 'result' : 'results'}</p>
+		</div>
+	)
+}

--- a/src/renderer/components/number-results.tsx
+++ b/src/renderer/components/number-results.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 
 export interface NumberResultsProps {
-	numberOfResults: number | undefined;
+	numberOfResults: number;
 }
 
 export default function NumberResults(props: NumberResultsProps){
-	const conversion = (numberToConvert: number | undefined): string => {
+	const conversion = (numberToConvert: number): string => {
 		if(numberToConvert){
 			return numberToConvert.toLocaleString();
 		}else{

--- a/src/renderer/components/number-results.tsx
+++ b/src/renderer/components/number-results.tsx
@@ -6,11 +6,7 @@ export interface NumberResultsProps {
 
 export default function NumberResults(props: NumberResultsProps){
 	const conversion = (numberToConvert: number): string => {
-		if(numberToConvert){
-			return numberToConvert.toLocaleString();
-		}else{
-			return '0'
-		}
+		return numberToConvert.toLocaleString();
 	}
 
 	return (

--- a/src/renderer/styles/logtable.less
+++ b/src/renderer/styles/logtable.less
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding: 2.2rem 2.2rem 0 0;
+  padding: 1.2rem 2.2rem 0 0;
   user-select: none;
 
   &.Single {

--- a/src/renderer/styles/numberOfResults.less
+++ b/src/renderer/styles/numberOfResults.less
@@ -1,0 +1,19 @@
+#numberResultsContainer {
+	padding: 1rem 2.2rem 0rem 2.2rem;
+	display: flex;
+	gap: .5rem;
+	align-items: baseline;
+}
+
+#numberResults {
+	font-size: large;
+	font-weight: bold;
+	margin: 0;
+}
+
+#resultTag{
+	font-size: 14px;
+	font-weight: 400;
+	margin: 0;
+	color:#a7b6c2;
+}

--- a/src/renderer/styles/styles.less
+++ b/src/renderer/styles/styles.less
@@ -26,3 +26,4 @@
 @import "net-log-view.less";
 @import "cachetool.less";
 @import "scrollbar.less";
+@import "numberOfResults.less";

--- a/test/renderer/rtl-new/numberOfResults.test.tsx
+++ b/test/renderer/rtl-new/numberOfResults.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import  NumberResults from '../../../src/renderer/components/number-results';
+import { render, screen} from '@testing-library/react';
+
+jest.mock('electron')
+
+describe('results', () => {
+	it('shows the results number in correct format', () => {
+		const resultLength: number = 20342;
+		render(<NumberResults numberOfResults={resultLength} />);
+		const result = screen.getByText('20,342');
+		expect(result).toBeInTheDocument();
+	});
+
+	it('when result number is 1, should use result not results (grammar)', () => {
+		const resultLength: number = 1;
+		render(<NumberResults numberOfResults={resultLength} />);
+		const result = screen.getByText('result');
+		expect(result).toBeInTheDocument();
+	})
+});

--- a/test/renderer/rtl-new/numberOfResults.test.tsx
+++ b/test/renderer/rtl-new/numberOfResults.test.tsx
@@ -6,14 +6,14 @@ jest.mock('electron')
 
 describe('results', () => {
 	it('shows the results number in correct format', () => {
-		const resultLength: number = 20342;
+		const resultLength= 20342;
 		render(<NumberResults numberOfResults={resultLength} />);
 		const result = screen.getByText('20,342');
 		expect(result).toBeInTheDocument();
 	});
 
 	it('when result number is 1, should use result not results (grammar)', () => {
-		const resultLength: number = 1;
+		const resultLength = 1;
 		render(<NumberResults numberOfResults={resultLength} />);
 		const result = screen.getByText('result');
 		expect(result).toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/tinyspeck/sleuth/issues/80 by displaying the number of search results on top of the table and added a couple of tests for displaying the correct number and format + grammar.
Importance: Allows the user to see how many results match their filtering or search


https://github.com/tinyspeck/sleuth/assets/52749324/24541616-939d-4bcf-8cc1-6d7b7047c1d1

