### PR TITLE
fix(sidebar): merge logs work again

### DIFF
--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { ITreeNode, Tree, Icon, Position, Tooltip, Intent } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
-import { MergedFilesLoadStatus, ProcessedLogFile, SelectableLogType, Tool, UnzippedFile } from '../../interfaces';
+import { LogType, MergedFilesLoadStatus, ProcessedLogFile, SelectableLogType, Tool, UnzippedFile } from '../../interfaces';
 import { levelsHave } from '../../utils/level-counts';
 import { SleuthState } from '../state/sleuth';
 import { isProcessedLogFile } from '../../utils/is-logfile';
@@ -56,7 +56,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     hasCaret: false,
     label: 'All Desktop Logs',
     icon: 'compressed',
-    nodeData: { type: 'all' }
+    nodeData: { type: LogType.ALL }
   }, {
     id: NODE_ID.BROWSER,
     hasCaret: true,
@@ -64,7 +64,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     label: 'Browser Process',
     isExpanded: true,
     childNodes: [],
-    nodeData: { type: 'browser' }
+    nodeData: { type: LogType.BROWSER }
   }, {
     id: NODE_ID.TRACE,
     hasCaret: true,
@@ -72,7 +72,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     label: 'Trace',
     isExpanded: true,
     childNodes: [],
-    nodeData: { type: 'trace' }
+    nodeData: { type: LogType.TRACE }
   }, {
     id: NODE_ID.CHROMIUM,
     hasCaret: true,
@@ -86,7 +86,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     label: 'Renderer Process',
     isExpanded: true,
     childNodes: [],
-    nodeData: { type: 'renderer' }
+    nodeData: { type: LogType.RENDERER }
   }, {
     id: NODE_ID.PRELOAD,
     hasCaret: true,
@@ -94,7 +94,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     label: 'BrowserView Process',
     isExpanded: true,
     childNodes: [],
-    nodeData: { type: 'preload' },
+    nodeData: { type: LogType.PRELOAD },
   }, {
     id: NODE_ID.WEBAPP,
     hasCaret: true,
@@ -102,7 +102,7 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     label: 'WebApp',
     isExpanded: true,
     childNodes: [],
-    nodeData: { type: 'webapp' }
+    nodeData: { type: LogType.WEBAPP }
   }, {
     id: NODE_ID.CALLS,
     hasCaret: true,

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -311,10 +311,10 @@ export class SleuthState {
       d(`Selecting log file ${name}`);
 
       this.selectedLogFile = logFile;
-    } else if (logType && logType in LogType && this.mergedLogFiles) {
+    } else if (logType && Object.values(LogType).includes(logType as LogType) && this.mergedLogFiles) {
       d(`Selecting log type ${logType}`);
-      this.mergedLogFiles[logType as KnownLogType];
-    } else if (logType && logType in Tool) {
+      this.selectedLogFile = this.mergedLogFiles[logType as KnownLogType];
+    } else if (logType && Object.values(Tool).includes(logType as Tool)) {
       this.selectedLogFile = (logType as Tool);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7170,6 +7170,15 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"


### PR DESCRIPTION
Two bugs here:

1. `logType in LogType` didn't work because string enums don't have a reverse map.
2. I forgot to assign `this.selectedLogFile`.