### PR TITLE
build: Upgrade to latest Electron stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "20.3.11",
+    "electron": "22.3.16",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",
     "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "24.6.2",
+    "electron": "25.2.0",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",
     "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "22.3.16",
+    "electron": "24.6.2",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",
     "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0",
     "less": "^3.12.2",
-    "node-abi": "^2.19.3",
+    "node-abi": "^3.45.0",
     "parcel-bundler": "^1.12.4",
     "patch-package": "^7.0.0",
     "react-addons-test-utils": "^15.6.2",
@@ -114,6 +114,7 @@
   },
   "resolutions": {
     "@types/react": "16.14.43",
-    "mobx-react-lite": "2.2.0"
+    "mobx-react-lite": "2.2.0",
+    "node-abi": "^3.45.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "14.2.9",
+    "electron": "20.3.11",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",
     "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "13.3.0",
+    "electron": "14.2.9",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",
     "http-proxy": "^1.18.1",

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -1,5 +1,4 @@
 export const enum IpcEvents {
-  ARE_YOU_BUSY = 'ARE_YOU_BUSY',
   GET_PATH = 'GET_PATH',
   GET_USER_AGENT = 'GET_USER_AGENT',
   WINDOW_READY = 'WINDOW_READY',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,8 +15,6 @@ if (!config.isDevMode) {
   process.env.NODE_ENV = 'production';
 }
 
-app.allowRendererProcessReuse = false;
-
 if (require('electron-squirrel-startup')) {
   // No-op, we're done here
 } else {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -127,7 +127,6 @@ export class IpcManager {
       | 'home'
       | 'appData'
       | 'userData'
-      | 'cache'
       | 'temp'
       | 'exe'
       | 'module'

--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -23,11 +23,5 @@ export function secureApp() {
         event.preventDefault();
       }
     });
-
-    // Disallow new-window
-    webContents.on('new-window', (event, url) => {
-      console.warn(`Prevented new-window for ${url}`);
-      event.preventDefault();
-    });
   });
 }

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -9,7 +9,7 @@ import { config } from '../config';
 import { getIconPath } from './app-icon';
 import { ICON_NAMES } from '../shared-constants';
 import { TouchBarManager } from './touch-bar-manager';
-import { IpcEvents } from '../ipc-events';
+// import { IpcEvents } from '../ipc-events';
 
 export let windows: Array<Electron.BrowserWindow> = [];
 
@@ -137,19 +137,6 @@ export async function getCurrentWindow(): Promise<BrowserWindow> {
 
   if (focused) {
     return focused;
-  }
-
-  // No window focused? Find a ready one
-  for (const window of windows) {
-    const isBusy = window.webContents.send(
-      IpcEvents.ARE_YOU_BUSY,
-    ) as unknown as boolean;
-
-    console.log(`Asked window ${window.id} if it's busy. Answer: ${isBusy}`);
-
-    if (isBusy === false) {
-      return window;
-    }
   }
 
   // None ready or focused? The first one then.

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -285,7 +285,7 @@ export class App extends React.Component<object, Partial<AppState>> {
    * handling a set of logfiles.
    */
   private setupBusyResponse() {
-    ipcRenderer.on(IpcEvents.ARE_YOU_BUSY, (event) => {
+    ipcRenderer.on(IpcEvents.ARE_YOU_BUSY, (event: any) => {
       const { unzippedFiles } = this.state;
 
       event.returnValue = !(!unzippedFiles || unzippedFiles.length === 0);

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -56,7 +56,6 @@ export class App extends React.Component<object, Partial<AppState>> {
     sendWindowReady();
 
     this.setupFileDrop();
-    this.setupBusyResponse();
     this.setupOpenSentry();
     this.setupWindowTitle();
   }
@@ -277,18 +276,6 @@ export class App extends React.Component<object, Partial<AppState>> {
 
       // Then, let the utility handle the details
       openSentry(installationFile?.fullPath);
-    });
-  }
-
-  /**
-   * Sometimes, the main process wants to know whether or not this window is currently
-   * handling a set of logfiles.
-   */
-  private setupBusyResponse() {
-    ipcRenderer.on(IpcEvents.ARE_YOU_BUSY, (event: any) => {
-      const { unzippedFiles } = this.state;
-
-      event.returnValue = !(!unzippedFiles || unzippedFiles.length === 0);
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,7 +1521,23 @@
     "@electron-forge/template-base" "6.0.0-beta.54"
     fs-extra "^9.0.1"
 
-"@electron/get@^1.0.1", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
+"@electron/get@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
+  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^9.6.0"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^3.0.0"
+    global-tunnel-ng "^2.7.1"
+
+"@electron/get@^1.6.0", "@electron/get@^1.9.0":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.12.2.tgz#6442066afb99be08cefb9a281e4b4692b33764f3"
   integrity sha512-vAuHUbfvBQpYTJ5wB7uVIDq5c/Ry0fiTBMs7lnEYAo/qXXppIVcWdfBr57u6eRnKdVso7KSiH6p/LbQAG6Izrg==
@@ -2432,10 +2448,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.7", "@types/node@^14.6.2":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.7":
   version "14.17.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.9.tgz#b97c057e6138adb7b720df2bd0264b03c9f504fd"
   integrity sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==
+
+"@types/node@^16.11.26":
+  version "16.18.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.38.tgz#1dcdb6c54d02b323f621213745f2e44af30c73e6"
+  integrity sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==
 
 "@types/prettier@^2.1.5":
   version "2.7.3"
@@ -4585,7 +4606,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concat-stream@^1.6.2, concat-stream@~1.6.0:
+concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -5029,7 +5050,7 @@ debounce@^1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -5651,14 +5672,14 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@14.2.9:
-  version "14.2.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.9.tgz#9e1e95643ec3847592a186e8115d1ddb2e4921ee"
-  integrity sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==
+electron@20.3.11:
+  version "20.3.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-20.3.11.tgz#dd3a1a26edecd012a807ae96409d52d0a0cc4f11"
+  integrity sha512-+dZRzUCDIeVcOqha4hW/y/rNOjoM23rcuLQgrdzayj2FHfgs8mud6fAzvTeJN3TT2c6em/u5cZYQXqdrYcZqAg==
   dependencies:
-    "@electron/get" "^1.0.1"
-    "@types/node" "^14.6.2"
-    extract-zip "^1.0.3"
+    "@electron/get" "^1.14.1"
+    "@types/node" "^16.11.26"
+    extract-zip "^2.0.1"
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6207,17 +6228,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^1.0.3:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
-  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
-  dependencies:
-    concat-stream "^1.6.2"
-    debug "^2.6.9"
-    mkdirp "^0.5.4"
-    yauzl "^2.10.0"
-
-extract-zip@^2.0.0:
+extract-zip@^2.0.0, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -6781,6 +6792,18 @@ global-agent@^2.0.2:
   dependencies:
     boolean "^3.0.1"
     core-js "^3.6.5"
+    es6-error "^4.1.1"
+    matcher "^3.0.0"
+    roarr "^2.15.3"
+    semver "^7.3.2"
+    serialize-error "^7.0.1"
+
+global-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6"
+  integrity sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==
+  dependencies:
+    boolean "^3.0.1"
     es6-error "^4.1.1"
     matcher "^3.0.0"
     roarr "^2.15.3"
@@ -9156,7 +9179,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -12018,6 +12041,11 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^6.2.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,17 +9271,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@^2.19.1, node-abi@^2.19.3:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.0.tgz#8be53bf3e7945a34eea10e0fc9a5982776cf550b"
-  integrity sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
-  dependencies:
-    semver "^5.4.1"
-
-node-abi@^3.0.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.5.0.tgz#26e8b7b251c3260a5ac5ba5aef3b4345a0229248"
-  integrity sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==
+node-abi@^2.19.1, node-abi@^3.0.0, node-abi@^3.45.0:
+  version "3.45.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.45.0.tgz#f568f163a3bfca5aacfce1fbeee1fa2cc98441f5"
+  integrity sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==
   dependencies:
     semver "^7.3.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,22 +1521,6 @@
     "@electron-forge/template-base" "6.0.0-beta.54"
     fs-extra "^9.0.1"
 
-"@electron/get@^1.14.1":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
-  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
-  dependencies:
-    debug "^4.1.1"
-    env-paths "^2.2.0"
-    fs-extra "^8.1.0"
-    got "^9.6.0"
-    progress "^2.0.3"
-    semver "^6.2.0"
-    sumchecker "^3.0.1"
-  optionalDependencies:
-    global-agent "^3.0.0"
-    global-tunnel-ng "^2.7.1"
-
 "@electron/get@^1.6.0", "@electron/get@^1.9.0":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.12.2.tgz#6442066afb99be08cefb9a281e4b4692b33764f3"
@@ -1552,6 +1536,21 @@
   optionalDependencies:
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
+
+"@electron/get@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"
+  integrity sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^11.8.5"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^3.0.0"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -4139,6 +4138,19 @@ cacheable-request@^7.0.1:
     normalize-url "^4.1.0"
     responselike "^2.0.0"
 
+cacheable-request@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
+  integrity sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
+
 cachetool@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cachetool/-/cachetool-1.1.2.tgz#868df8adb23ae0ecaa68db465fdb589cd1bbbc61"
@@ -5672,12 +5684,12 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@20.3.11:
-  version "20.3.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-20.3.11.tgz#dd3a1a26edecd012a807ae96409d52d0a0cc4f11"
-  integrity sha512-+dZRzUCDIeVcOqha4hW/y/rNOjoM23rcuLQgrdzayj2FHfgs8mud6fAzvTeJN3TT2c6em/u5cZYQXqdrYcZqAg==
+electron@22.3.16:
+  version "22.3.16"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.16.tgz#da7ef2ff79d05e8d3f4e01cfb9f47e7bf1d15ec3"
+  integrity sha512-8dHTKetzhfF6Ez7ggLznNtZ8gUPuBUiLVlhd0iGxASn483m2GcOGLB5HmRVEcw/FSNd2nLfWdsbzA6HlMf/UbA==
   dependencies:
-    "@electron/get" "^1.14.1"
+    "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"
     extract-zip "^2.0.1"
 
@@ -6901,6 +6913,23 @@ got@^11.7.0:
     "@types/responselike" "^1.0.0"
     cacheable-lookup "^5.0.3"
     cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
+got@^11.8.5:
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
     decompress-response "^6.0.0"
     http2-wrapper "^1.0.0-beta.5.2"
     lowercase-keys "^2.0.0"
@@ -9478,6 +9507,11 @@ normalize-url@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 normalize.css@^8.0.1:
   version "8.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5651,10 +5651,10 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.3.0.tgz#5f4f245723dd50fcd2c3d386a1d66fe748af404f"
-  integrity sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==
+electron@14.2.9:
+  version "14.2.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.9.tgz#9e1e95643ec3847592a186e8115d1ddb2e4921ee"
+  integrity sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2452,10 +2452,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.9.tgz#b97c057e6138adb7b720df2bd0264b03c9f504fd"
   integrity sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==
 
-"@types/node@^16.11.26":
-  version "16.18.38"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.38.tgz#1dcdb6c54d02b323f621213745f2e44af30c73e6"
-  integrity sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==
+"@types/node@^18.11.18":
+  version "18.16.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
+  integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==
 
 "@types/prettier@^2.1.5":
   version "2.7.3"
@@ -5684,13 +5684,13 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@22.3.16:
-  version "22.3.16"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.16.tgz#da7ef2ff79d05e8d3f4e01cfb9f47e7bf1d15ec3"
-  integrity sha512-8dHTKetzhfF6Ez7ggLznNtZ8gUPuBUiLVlhd0iGxASn483m2GcOGLB5HmRVEcw/FSNd2nLfWdsbzA6HlMf/UbA==
+electron@24.6.2:
+  version "24.6.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
+  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^16.11.26"
+    "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
 elliptic@^6.5.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5684,10 +5684,10 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@24.6.2:
-  version "24.6.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
-  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
+electron@25.2.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.2.0.tgz#ff832d88f78481a82cf9feb72e605ec43553d4ba"
+  integrity sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
## Description
Sleuth is currently running on Electron v13.3.0, which is not a stable version ([see here](https://releases.electronjs.org/)). To stay up to date with security best practices, bug fixes, performance enhancements and future maintenance, upgrading Sleuth to the latest stable version is needed. 

This PR upgrades Sleuth to Electron v25.2.0 (latest at this time) and fixes #68 

## Notes

-  When loading up Sleuth in `DevMode`, a white window will appear for a few seconds before Sleuth appears. This doesn't appear in production and doesn't impact performance.
- Removed `app.allowRendererProcessReuse` as it is no longer supported and was [removed](https://releases.electronjs.org/release/v14.0.0) in Electron v14.0.0
- Removed `cache` from `type name` as it was removed from `app.getPath` [here](https://github.com/electron/electron/pull/33509)
- Removed `new-window` function due to `new-window` event being deprecated in Electron 13 and [removed](https://github.com/electron/electron/pull/34526) in Electron 22 
- Removed `ARE_YOU_BUSY` IPC Event and associated functions due to being unused and dead-code
