### PR TITLE
chore: remove support for call logs

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,7 +15,6 @@ export enum LogType {
   PRELOAD = 'preload',
   WEBAPP = 'webapp',
   STATE = 'state',
-  CALL = 'call',
   NETLOG = 'netlog',
   TRACE = 'trace',
   INSTALLER = 'installer',
@@ -32,7 +31,6 @@ export const LOG_TYPES_TO_PROCESS = [
   LogType.RENDERER,
   LogType.WEBAPP,
   LogType.PRELOAD,
-  LogType.CALL,
   LogType.INSTALLER,
   LogType.MOBILE,
   LogType.CHROMIUM,
@@ -141,7 +139,6 @@ export interface MergedFilesLoadStatus {
   renderer: boolean;
   preload: boolean;
   webapp: boolean;
-  call: boolean;
   mobile: boolean;
 }
 

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -54,7 +54,6 @@ export class CoreApplication extends React.Component<
         preload: [],
         webapp: [],
         state: [],
-        call: [],
         installer: [],
         netlog: [],
         trace: [],
@@ -191,9 +190,6 @@ export class CoreApplication extends React.Component<
       await mergeLogFiles(processedLogFiles.preload, LogType.PRELOAD).then(
         setMergedFile,
       );
-      await mergeLogFiles(processedLogFiles.call, LogType.CALL).then(
-        setMergedFile,
-      );
       await mergeLogFiles(processedLogFiles.webapp, LogType.WEBAPP).then(
         setMergedFile,
       );
@@ -203,7 +199,6 @@ export class CoreApplication extends React.Component<
         merged.browser,
         merged.renderer,
         merged.preload,
-        merged.call,
         merged.webapp,
       ];
 
@@ -261,11 +256,6 @@ export class CoreApplication extends React.Component<
         mergedLogFiles &&
         mergedLogFiles.webapp &&
         mergedLogFiles.webapp.logEntries
-      ),
-      call: !!(
-        mergedLogFiles &&
-        mergedLogFiles.call &&
-        mergedLogFiles.call.logEntries
       ),
       mobile: !!(
         mergedLogFiles &&

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -660,10 +660,6 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
           className="Meta Color-Preload ts_icon ts_icon_all_files_alt"
         />
       );
-    } else if (entry.logType === 'call') {
-      prefix = (
-        <i title="Call Log" className="Meta Color-Call ts_icon ts_icon_phone" />
-      );
     } else if (entry.logType === 'mobile') {
       prefix = (
         <i

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -49,7 +49,6 @@ const enum NODE_ID {
   PRELOAD = 'preload',
   TRACE = 'trace',
   WEBAPP = 'webapp',
-  CALLS = 'calls',
   INSTALLER = 'installer',
   NETWORK = 'network',
   CACHE = 'cache',
@@ -126,14 +125,6 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     nodeData: { type: LogType.WEBAPP },
   },
   {
-    id: NODE_ID.CALLS,
-    hasCaret: true,
-    icon: 'phone',
-    label: 'Calls',
-    isExpanded: true,
-    childNodes: [],
-  },
-  {
     id: NODE_ID.INSTALLER,
     hasCaret: true,
     icon: 'automatic-updates',
@@ -203,11 +194,6 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       NODE_ID.WEBAPP,
       state,
       processedLogFiles.webapp.map((file) => Sidebar.getFileNode(file, props)),
-    );
-    Sidebar.setChildNodes(
-      NODE_ID.CALLS,
-      state,
-      processedLogFiles.call.map((file) => Sidebar.getFileNode(file, props)),
     );
     Sidebar.setChildNodes(
       NODE_ID.INSTALLER,

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -191,8 +191,6 @@ export function getTypeForFile(
     fileName.startsWith('console')
   ) {
     return LogType.WEBAPP;
-  } else if (fileName.startsWith('call')) {
-    return LogType.CALL;
   } else if (
     (fileName.startsWith('net') &&
       !fileName.includes('net-log-window-console')) ||
@@ -233,7 +231,6 @@ export function getTypeForFile(
 export function getTypesForFiles(logFiles: UnzippedFiles): SortedUnzippedFiles {
   const result: SortedUnzippedFiles = {
     browser: [],
-    call: [],
     renderer: [],
     webapp: [],
     preload: [],
@@ -402,7 +399,6 @@ export function readFile(
     });
     const parsedlogType = logType || getTypeForFile(logFile);
     const matchFn = getMatchFunction(parsedlogType, logFile);
-    const isCall = logType === 'call';
 
     let lines = 0;
     let lastLogged = 0;
@@ -539,10 +535,7 @@ export function readFile(
         current = makeLogEntry(matched, parsedlogType, lines, logFile.fullPath);
       } else {
         // We couldn't match, let's treat it
-        if (isCall && current) {
-          // Call logs sometimes have random newlines
-          current.message += line;
-        } else if (logType === 'mobile' && current) {
+        if (logType === 'mobile' && current) {
           // Android logs do too
           current.message += '\n' + line;
         } else if (
@@ -1003,35 +996,6 @@ export function matchLineMobile(line: string): MatchResult | undefined {
   return results;
 }
 
-/**
- * Matches a Call line
- *
- * @param {string} line
- * @returns {(MatchResult | undefined)}
- */
-export function matchLineCall(line: string): MatchResult | undefined {
-  // Matcher for calls
-  // [YYYY/MM/DD hh:mm:ss uuu* LEVEL FILE->FUNCTION:LINE] message
-  const callRegex =
-    // eslint-disable-next-line no-control-regex
-    /(\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}\.\d{3})	([A-Z]{0,10}) ([\s\S]*)$/;
-  const results = callRegex.exec(line);
-
-  if (results && results.length === 4) {
-    // Expected format: YYYY/MM/DD hh:mm:ss.SSS
-    const momentValue = new Date(results[1]).valueOf();
-
-    return {
-      timestamp: results[1],
-      level: results[2],
-      message: results[3],
-      momentValue,
-    };
-  }
-
-  return;
-}
-
 export function matchLineChromium(line: string): MatchResult | undefined {
   // See format: https://support.google.com/chrome/a/answer/6271282
   const results = CHROMIUM_RGX.exec(line);
@@ -1103,8 +1067,6 @@ export function getMatchFunction(
     } else {
       return matchLineWebApp;
     }
-  } else if (logType === LogType.CALL) {
-    return matchLineCall;
   } else if (logType === LogType.INSTALLER) {
     if (logFile.fileName.includes('Squirrel')) {
       return matchLineSquirrel;

--- a/src/renderer/styles/colors.less
+++ b/src/renderer/styles/colors.less
@@ -14,10 +14,6 @@
   color: #f8b82c;
 }
 
-.Color-Call {
-  color: #f8b82c;
-}
-
 .Color-Mobile {
   color: #e32072;
 }
@@ -27,7 +23,6 @@
 @renderer_color: #7fd1e0;
 @webapp_color: #42c299;
 @preload_color: #f8b82c;
-@call_color: #f8b82c;
 @mention_yellow: #fff3b8;
 @highlight_yellow: #fffce0;
 @slate_blue_grey: #4d5a68;

--- a/src/utils/get-first-logfile.ts
+++ b/src/utils/get-first-logfile.ts
@@ -8,7 +8,6 @@ export function getFirstLogFile(
     if (files.renderer && files.renderer.length > 0) return files.renderer[0];
     if (files.preload && files.preload.length > 0) return files.preload[0];
     if (files.webapp && files.webapp.length > 0) return files.webapp[0];
-    if (files.call && files.call.length > 0) return files.call[0];
     if (files.netlog && files.netlog.length > 0) return files.netlog[0];
     if (files.trace && files.trace.length > 0) return files.netlog[0];
     if (files.installer && files.installer.length > 0)

--- a/test/utils/get-first-logfile.test.ts
+++ b/test/utils/get-first-logfile.test.ts
@@ -19,7 +19,6 @@ const fakeFile: ProcessedLogFile = {
 const files: ProcessedLogFiles = {
   browser: [],
   renderer: [],
-  call: [],
   webapp: [],
   preload: [],
   state: [],
@@ -34,7 +33,6 @@ describe('getFirstLogFile', () => {
   afterEach(() => {
     files.browser = [];
     files.renderer = [];
-    files.call = [];
     files.webapp = [];
     files.state = [];
   });
@@ -49,13 +47,6 @@ describe('getFirstLogFile', () => {
   it('should return the first logfile (renderer if available)', () => {
     fakeFile.logType = LogType.RENDERER;
     files.renderer = [fakeFile];
-
-    expect(getFirstLogFile(files)).toEqual(fakeFile);
-  });
-
-  it('should return the first logfile (call if available)', () => {
-    fakeFile.logType = LogType.CALL;
-    files.call = [fakeFile];
 
     expect(getFirstLogFile(files)).toEqual(fakeFile);
   });


### PR DESCRIPTION
## Description

Due to Slack Calls being replaced by Huddles, the need to collect for `Call` logs is no longer needed. Therefore, removing support for them will be beneficial to Sleuth in terms of performance + code cleanliness.

ref #111 