### PR TITLE
chore: remove support for preload logs

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,6 @@ export type RepeatedCounts = Record<string, number>;
 export enum LogType {
   ALL = 'all',
   BROWSER = 'browser',
-  RENDERER = 'renderer',
   PRELOAD = 'preload',
   WEBAPP = 'webapp',
   STATE = 'state',
@@ -29,7 +28,6 @@ export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 
 export const LOG_TYPES_TO_PROCESS = [
   LogType.BROWSER,
-  LogType.RENDERER,
   LogType.WEBAPP,
   LogType.PRELOAD,
   LogType.CALL,
@@ -138,7 +136,6 @@ export interface MergedLogFile extends BaseFile {
 export interface MergedFilesLoadStatus {
   all: boolean;
   browser: boolean;
-  renderer: boolean;
   preload: boolean;
   webapp: boolean;
   call: boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,6 @@ export type RepeatedCounts = Record<string, number>;
 export enum LogType {
   ALL = 'all',
   BROWSER = 'browser',
-  PRELOAD = 'preload',
   WEBAPP = 'webapp',
   STATE = 'state',
   NETLOG = 'netlog',
@@ -28,7 +27,6 @@ export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 export const LOG_TYPES_TO_PROCESS = [
   LogType.BROWSER,
   LogType.WEBAPP,
-  LogType.PRELOAD,
   LogType.INSTALLER,
   LogType.MOBILE,
   LogType.CHROMIUM,
@@ -134,7 +132,6 @@ export interface MergedLogFile extends BaseFile {
 export interface MergedFilesLoadStatus {
   all: boolean;
   browser: boolean;
-  preload: boolean;
   webapp: boolean;
   mobile: boolean;
 }

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -50,7 +50,6 @@ export class CoreApplication extends React.Component<
     this.state = {
       processedLogFiles: {
         browser: [],
-        renderer: [],
         preload: [],
         webapp: [],
         state: [],
@@ -185,9 +184,6 @@ export class CoreApplication extends React.Component<
       await mergeLogFiles(processedLogFiles.browser, LogType.BROWSER).then(
         setMergedFile,
       );
-      await mergeLogFiles(processedLogFiles.renderer, LogType.RENDERER).then(
-        setMergedFile,
-      );
       await mergeLogFiles(processedLogFiles.preload, LogType.PRELOAD).then(
         setMergedFile,
       );
@@ -201,7 +197,6 @@ export class CoreApplication extends React.Component<
       const merged = this.props.state.mergedLogFiles as MergedLogFiles;
       const toMerge = [
         merged.browser,
-        merged.renderer,
         merged.preload,
         merged.call,
         merged.webapp,
@@ -246,11 +241,6 @@ export class CoreApplication extends React.Component<
         mergedLogFiles &&
         mergedLogFiles.browser &&
         mergedLogFiles.browser.logEntries
-      ),
-      renderer: !!(
-        mergedLogFiles &&
-        mergedLogFiles.renderer &&
-        mergedLogFiles.renderer.logEntries
       ),
       preload: !!(
         mergedLogFiles &&

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -50,7 +50,6 @@ export class CoreApplication extends React.Component<
     this.state = {
       processedLogFiles: {
         browser: [],
-        preload: [],
         webapp: [],
         state: [],
         installer: [],
@@ -183,15 +182,12 @@ export class CoreApplication extends React.Component<
       await mergeLogFiles(processedLogFiles.browser, LogType.BROWSER).then(
         setMergedFile,
       );
-      await mergeLogFiles(processedLogFiles.preload, LogType.PRELOAD).then(
-        setMergedFile,
-      );
       await mergeLogFiles(processedLogFiles.webapp, LogType.WEBAPP).then(
         setMergedFile,
       );
 
       const merged = this.props.state.mergedLogFiles as MergedLogFiles;
-      const toMerge = [merged.browser, merged.preload, merged.webapp];
+      const toMerge = [merged.browser, merged.webapp];
 
       mergeLogFiles(toMerge, LogType.ALL).then((r) => setMergedFile(r));
     }
@@ -232,11 +228,6 @@ export class CoreApplication extends React.Component<
         mergedLogFiles &&
         mergedLogFiles.browser &&
         mergedLogFiles.browser.logEntries
-      ),
-      preload: !!(
-        mergedLogFiles &&
-        mergedLogFiles.preload &&
-        mergedLogFiles.preload.logEntries
       ),
       webapp: !!(
         mergedLogFiles &&

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -191,11 +191,7 @@ export class CoreApplication extends React.Component<
       );
 
       const merged = this.props.state.mergedLogFiles as MergedLogFiles;
-      const toMerge = [
-        merged.browser,
-        merged.preload,
-        merged.webapp,
-      ];
+      const toMerge = [merged.browser, merged.preload, merged.webapp];
 
       mergeLogFiles(toMerge, LogType.ALL).then((r) => setMergedFile(r));
     }

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -639,13 +639,6 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
           className="Meta Color-Browser ts_icon ts_icon_power_off"
         />
       );
-    } else if (entry.logType === 'renderer') {
-      prefix = (
-        <i
-          title="Renderer Log"
-          className="Meta Color-Renderer ts_icon ts_icon_laptop"
-        />
-      );
     } else if (entry.logType === 'webapp') {
       prefix = (
         <i

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -646,13 +646,6 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
           className="Meta Color-Webapp ts_icon ts_icon_globe"
         />
       );
-    } else if (entry.logType === 'preload') {
-      prefix = (
-        <i
-          title="Preload Log"
-          className="Meta Color-Preload ts_icon ts_icon_all_files_alt"
-        />
-      );
     } else if (entry.logType === 'mobile') {
       prefix = (
         <i

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -45,7 +45,6 @@ const enum NODE_ID {
   ALL = 'all-desktop',
   STATE = 'state',
   BROWSER = 'browser',
-  RENDERER = 'renderer',
   PRELOAD = 'preload',
   TRACE = 'trace',
   WEBAPP = 'webapp',
@@ -97,15 +96,6 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     icon: 'modal',
     label: 'Chromium',
     isExpanded: true,
-  },
-  {
-    id: NODE_ID.RENDERER,
-    hasCaret: true,
-    icon: 'applications',
-    label: 'Renderer Process',
-    isExpanded: true,
-    childNodes: [],
-    nodeData: { type: LogType.RENDERER },
   },
   {
     id: NODE_ID.PRELOAD,
@@ -186,13 +176,6 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       NODE_ID.BROWSER,
       state,
       processedLogFiles.browser.map((file) => Sidebar.getFileNode(file, props)),
-    );
-    Sidebar.setChildNodes(
-      NODE_ID.RENDERER,
-      state,
-      processedLogFiles.renderer.map((file) =>
-        Sidebar.getFileNode(file, props),
-      ),
     );
     Sidebar.setChildNodes(
       NODE_ID.PRELOAD,
@@ -510,10 +493,9 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       return;
     }
 
-    // Renderer and Preload is on their way out, so let's not show
+    // Preload is on their way out, so let's not show
     // these categories if we don't have files for them
-    const hideIfEmpty =
-      searchId === NODE_ID.PRELOAD || searchId === NODE_ID.RENDERER;
+    const hideIfEmpty = searchId === NODE_ID.PRELOAD;
     if (childNodes.length === 0 && hideIfEmpty) {
       state.nodes = state.nodes.filter(({ id }) => searchId !== id);
     }

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -45,7 +45,6 @@ const enum NODE_ID {
   ALL = 'all-desktop',
   STATE = 'state',
   BROWSER = 'browser',
-  PRELOAD = 'preload',
   TRACE = 'trace',
   WEBAPP = 'webapp',
   INSTALLER = 'installer',
@@ -95,15 +94,6 @@ const DEFAULT_NODES: Array<ITreeNode> = [
     icon: 'modal',
     label: 'Chromium',
     isExpanded: true,
-  },
-  {
-    id: NODE_ID.PRELOAD,
-    hasCaret: true,
-    icon: 'applications',
-    label: 'BrowserView Process',
-    isExpanded: true,
-    childNodes: [],
-    nodeData: { type: LogType.PRELOAD },
   },
   {
     id: NODE_ID.WEBAPP,
@@ -167,11 +157,6 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       NODE_ID.BROWSER,
       state,
       processedLogFiles.browser.map((file) => Sidebar.getFileNode(file, props)),
-    );
-    Sidebar.setChildNodes(
-      NODE_ID.PRELOAD,
-      state,
-      processedLogFiles.preload.map((file) => Sidebar.getFileNode(file, props)),
     );
     Sidebar.setChildNodes(
       NODE_ID.WEBAPP,
@@ -477,13 +462,6 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
 
     if (!parentNode) {
       return;
-    }
-
-    // Preload is on their way out, so let's not show
-    // these categories if we don't have files for them
-    const hideIfEmpty = searchId === NODE_ID.PRELOAD;
-    if (childNodes.length === 0 && hideIfEmpty) {
-      state.nodes = state.nodes.filter(({ id }) => searchId !== id);
     }
 
     parentNode.childNodes = childNodes;

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -151,7 +151,7 @@ export function mergeLogFiles(
 }
 
 /**
- * Takes a logfile and returns the file's type (browser/renderer/webapp/preload/mobile).
+ * Takes a logfile and returns the file's type (browser/webapp/preload/mobile).
  *
  * @param {UnzippedFile} logFile
  * @returns {LogType}
@@ -173,18 +173,6 @@ export function getTypeForFile(
     fileName.startsWith('webview')
   ) {
     return LogType.PRELOAD;
-  } else if (
-    fileName.startsWith('renderer') ||
-    fileName === 'epics-renderer.log' ||
-    fileName.startsWith('google') ||
-    fileName.startsWith('onedrive') ||
-    fileName.startsWith('box') ||
-    fileName.startsWith('dropbox') ||
-    fileName.startsWith('unknown') ||
-    fileName.endsWith('window-console.log') ||
-    fileName.endsWith('chrome-console.log')
-  ) {
-    return LogType.RENDERER;
   } else if (
     fileName.startsWith('webapp') ||
     fileName.startsWith('app.slack') ||
@@ -234,7 +222,6 @@ export function getTypesForFiles(logFiles: UnzippedFiles): SortedUnzippedFiles {
   const result: SortedUnzippedFiles = {
     browser: [],
     call: [],
-    renderer: [],
     webapp: [],
     preload: [],
     state: [],
@@ -739,7 +726,7 @@ export function matchLineShipItMac(line: string): MatchResult | undefined {
 }
 
 /**
- * Matches an Electron line (Browser, Renderer, Preload)
+ * Matches an Electron line (Browser, Preload)
  *
  * @param {string} line
  * @returns {(MatchResult | undefined)}

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -151,7 +151,7 @@ export function mergeLogFiles(
 }
 
 /**
- * Takes a logfile and returns the file's type (browser/webapp/preload/mobile).
+ * Takes a logfile and returns the file's type (browser/webapp/mobile).
  *
  * @param {UnzippedFile} logFile
  * @returns {LogType}
@@ -168,11 +168,6 @@ export function getTypeForFile(
     fileName === 'epics-browser.log'
   ) {
     return LogType.BROWSER;
-  } else if (
-    fileName.endsWith('preload.log') ||
-    fileName.startsWith('webview')
-  ) {
-    return LogType.PRELOAD;
   } else if (
     fileName.startsWith('webapp') ||
     fileName.startsWith('app.slack') ||
@@ -220,7 +215,6 @@ export function getTypesForFiles(logFiles: UnzippedFiles): SortedUnzippedFiles {
   const result: SortedUnzippedFiles = {
     browser: [],
     webapp: [],
-    preload: [],
     state: [],
     installer: [],
     netlog: [],
@@ -719,7 +713,7 @@ export function matchLineShipItMac(line: string): MatchResult | undefined {
 }
 
 /**
- * Matches an Electron line (Browser, Preload)
+ * Matches an Electron line (Browser)
  *
  * @param {string} line
  * @returns {(MatchResult | undefined)}

--- a/src/renderer/styles/colors.less
+++ b/src/renderer/styles/colors.less
@@ -2,10 +2,6 @@
   color: #e32072;
 }
 
-.Color-Renderer {
-  color: #7fd1e0;
-}
-
 .Color-Webapp {
   color: #42c299;
 }
@@ -24,7 +20,6 @@
 
 // Using a method allows us to alias
 @browser_color: #e32072;
-@renderer_color: #7fd1e0;
 @webapp_color: #42c299;
 @preload_color: #f8b82c;
 @call_color: #f8b82c;

--- a/src/renderer/styles/colors.less
+++ b/src/renderer/styles/colors.less
@@ -6,10 +6,6 @@
   color: #42c299;
 }
 
-.Color-Preload {
-  color: #f8b82c;
-}
-
 .Color-Mobile {
   color: #e32072;
 }
@@ -17,7 +13,6 @@
 // Using a method allows us to alias
 @browser_color: #e32072;
 @webapp_color: #42c299;
-@preload_color: #f8b82c;
 @mention_yellow: #fff3b8;
 @highlight_yellow: #fffce0;
 @slate_blue_grey: #4d5a68;

--- a/src/utils/get-first-logfile.ts
+++ b/src/utils/get-first-logfile.ts
@@ -5,7 +5,6 @@ export function getFirstLogFile(
 ): SelectableLogFile {
   if (files) {
     if (files.browser && files.browser.length > 0) return files.browser[0];
-    if (files.preload && files.preload.length > 0) return files.preload[0];
     if (files.webapp && files.webapp.length > 0) return files.webapp[0];
     if (files.netlog && files.netlog.length > 0) return files.netlog[0];
     if (files.trace && files.trace.length > 0) return files.netlog[0];

--- a/src/utils/get-first-logfile.ts
+++ b/src/utils/get-first-logfile.ts
@@ -5,7 +5,6 @@ export function getFirstLogFile(
 ): SelectableLogFile {
   if (files) {
     if (files.browser && files.browser.length > 0) return files.browser[0];
-    if (files.renderer && files.renderer.length > 0) return files.renderer[0];
     if (files.preload && files.preload.length > 0) return files.preload[0];
     if (files.webapp && files.webapp.length > 0) return files.webapp[0];
     if (files.call && files.call.length > 0) return files.call[0];

--- a/test/renderer/processor.test.ts
+++ b/test/renderer/processor.test.ts
@@ -144,11 +144,6 @@ describe('getTypesForFiles', () => {
         size: 0,
       },
       {
-        fileName: 'renderer-webapp-123-preload.log',
-        fullPath: '_',
-        size: 0,
-      },
-      {
         fileName: 'slack-teams.log',
         fullPath: '_',
         size: 0,
@@ -168,7 +163,6 @@ describe('getTypesForFiles', () => {
     const result = getTypesForFiles(files as UnzippedFiles);
     expect(result.browser).toHaveLength(1);
     expect(result.webapp).toHaveLength(1);
-    expect(result.preload).toHaveLength(1);
     expect(result.state).toHaveLength(3);
   });
 });
@@ -198,17 +192,6 @@ describe('getTypeForFile', () => {
         size: 0,
       }),
     ).toEqual('webapp');
-  });
-
-  it('should get the type for preload log files', () => {
-    expect(
-      getTypeForFile({
-        ...base,
-        fileName: 'renderer-webapp-44-preload.log',
-        fullPath: '_',
-        size: 0,
-      }),
-    ).toEqual('preload');
   });
 });
 

--- a/test/renderer/processor.test.ts
+++ b/test/renderer/processor.test.ts
@@ -139,16 +139,6 @@ describe('getTypesForFiles', () => {
         size: 0,
       },
       {
-        fileName: 'renderer-1.log',
-        fullPath: '_',
-        size: 0,
-      },
-      {
-        fileName: 'renderer-2.log',
-        fullPath: '_',
-        size: 0,
-      },
-      {
         fileName: 'webapp.log',
         fullPath: '_',
         size: 0,
@@ -177,7 +167,6 @@ describe('getTypesForFiles', () => {
 
     const result = getTypesForFiles(files as UnzippedFiles);
     expect(result.browser).toHaveLength(1);
-    expect(result.renderer).toHaveLength(2);
     expect(result.webapp).toHaveLength(1);
     expect(result.preload).toHaveLength(1);
     expect(result.state).toHaveLength(3);
@@ -198,17 +187,6 @@ describe('getTypeForFile', () => {
         size: 0,
       }),
     ).toEqual('browser');
-  });
-
-  it('should get the type for renderer log files', () => {
-    expect(
-      getTypeForFile({
-        ...base,
-        fileName: 'renderer-12.log',
-        fullPath: '_',
-        size: 0,
-      }),
-    ).toEqual('renderer');
   });
 
   it('should get the type for webapp log files', () => {

--- a/test/utils/get-first-logfile.test.ts
+++ b/test/utils/get-first-logfile.test.ts
@@ -18,7 +18,6 @@ const fakeFile: ProcessedLogFile = {
 
 const files: ProcessedLogFiles = {
   browser: [],
-  renderer: [],
   call: [],
   webapp: [],
   preload: [],
@@ -33,7 +32,6 @@ const files: ProcessedLogFiles = {
 describe('getFirstLogFile', () => {
   afterEach(() => {
     files.browser = [];
-    files.renderer = [];
     files.call = [];
     files.webapp = [];
     files.state = [];
@@ -42,13 +40,6 @@ describe('getFirstLogFile', () => {
   it('should return the first logfile (browser if available)', () => {
     fakeFile.logType = LogType.BROWSER;
     files.browser = [fakeFile];
-
-    expect(getFirstLogFile(files)).toEqual(fakeFile);
-  });
-
-  it('should return the first logfile (renderer if available)', () => {
-    fakeFile.logType = LogType.RENDERER;
-    files.renderer = [fakeFile];
 
     expect(getFirstLogFile(files)).toEqual(fakeFile);
   });

--- a/test/utils/get-first-logfile.test.ts
+++ b/test/utils/get-first-logfile.test.ts
@@ -19,7 +19,6 @@ const fakeFile: ProcessedLogFile = {
 const files: ProcessedLogFiles = {
   browser: [],
   webapp: [],
-  preload: [],
   state: [],
   netlog: [],
   installer: [],
@@ -45,13 +44,6 @@ describe('getFirstLogFile', () => {
   it('should return the first logfile (webapp if available)', () => {
     fakeFile.logType = LogType.WEBAPP;
     files.webapp = [fakeFile];
-
-    expect(getFirstLogFile(files)).toEqual(fakeFile);
-  });
-
-  it('should return the first logfile (preload if available)', () => {
-    fakeFile.logType = LogType.PRELOAD;
-    files.preload = [fakeFile];
 
     expect(getFirstLogFile(files)).toEqual(fakeFile);
   });


### PR DESCRIPTION
## Description

Due to `Preload` logs being deprecated and being incorporated under `WebApp` logs, Sleuth no longer needs to collect them. Therefore, removing support for them will be beneficial to Sleuth in terms of performance + code cleanliness.
