### PR TITLE
chore: ignore Prettier commit in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format the repo with prettier
+4a290fd25882b2667f8da8c0659e19eeee7ae875


### PR DESCRIPTION
Ignores 4a290fd25882b2667f8da8c0659e19eeee7ae875 in git blame.

See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view