### PR TITLE
feat: hide categories with no files in them

### DIFF
--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -466,7 +466,7 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
 
     // Do not show categories if they have no files in them
     if (childNodes.length === 0) {
-      state.nodes = state.nodes.filter(({id}) => searchId !== id)
+      state.nodes = state.nodes.filter(({ id }) => searchId !== id);
     }
 
     parentNode.childNodes = childNodes;

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -464,6 +464,11 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       return;
     }
 
+    // Do not show categories if they have no files in them
+    if (childNodes.length === 0) {
+      state.nodes = state.nodes.filter(({id}) => searchId !== id)
+    }
+
     parentNode.childNodes = childNodes;
   }
 

--- a/test/renderer/rtl-new/sidebar.test.tsx
+++ b/test/renderer/rtl-new/sidebar.test.tsx
@@ -1,86 +1,97 @@
-import React from "react";
-import { Sidebar } from "../../../src/renderer/components/sidebar"
-import { render, screen } from '@testing-library/react'
-import { SleuthState } from "../../../src/renderer/state/sleuth";
-import { ProcessedLogFile, ProcessedLogFiles, LogType, MergedFilesLoadStatus } from "../../../src/interfaces";
+import React from 'react';
+import { Sidebar } from '../../../src/renderer/components/sidebar';
+import { render, screen } from '@testing-library/react';
+import { SleuthState } from '../../../src/renderer/state/sleuth';
+import {
+  ProcessedLogFile,
+  ProcessedLogFiles,
+  LogType,
+  MergedFilesLoadStatus,
+} from '../../../src/interfaces';
 import { fakeUnzippedFile } from '../../__mocks__/unzipped-file';
 
-jest.mock('electron')
+jest.mock('electron');
 
 const fakeFile1: ProcessedLogFile = {
-	repeatedCounts: {},
-	id: '123',
-	logEntries: [],
-	logFile: fakeUnzippedFile,
-	logType: LogType.BROWSER,
-	type: 'ProcessedLogFile',
-	levelCounts: {},
-  };
+  repeatedCounts: {},
+  id: '123',
+  logEntries: [],
+  logFile: fakeUnzippedFile,
+  logType: LogType.BROWSER,
+  type: 'ProcessedLogFile',
+  levelCounts: {},
+};
 
 const fakeFile2: ProcessedLogFile = {
-	repeatedCounts: {},
-	id: '1234',
-	logEntries: [],
-	logFile: fakeUnzippedFile,
-	logType: LogType.CHROMIUM,
-	type: 'ProcessedLogFile',
-	levelCounts: {}
-}
+  repeatedCounts: {},
+  id: '1234',
+  logEntries: [],
+  logFile: fakeUnzippedFile,
+  logType: LogType.CHROMIUM,
+  type: 'ProcessedLogFile',
+  levelCounts: {},
+};
 
 const fakeFile3: ProcessedLogFile = {
-	repeatedCounts: {},
-	id: '12345',
-	logEntries: [],
-	logFile: fakeUnzippedFile,
-	logType: LogType.WEBAPP,
-	type: 'ProcessedLogFile',
-	levelCounts: {}
-}
-  
-  const files: ProcessedLogFiles = {
-	browser: [fakeFile1],
-	webapp: [fakeFile3],
-	state: [],
-	netlog: [],
-	installer: [],
-	trace: [],
-	mobile: [],
-	chromium: [fakeFile2],
-  };
+  repeatedCounts: {},
+  id: '12345',
+  logEntries: [],
+  logFile: fakeUnzippedFile,
+  logType: LogType.WEBAPP,
+  type: 'ProcessedLogFile',
+  levelCounts: {},
+};
+
+const files: ProcessedLogFiles = {
+  browser: [fakeFile1],
+  webapp: [fakeFile3],
+  state: [],
+  netlog: [],
+  installer: [],
+  trace: [],
+  mobile: [],
+  chromium: [fakeFile2],
+};
 
 describe('sidebar', () => {
-	it('hides the sidebar log types that dont have files in them', () => {
-		const state: Partial<SleuthState> = {
-			processedLogFiles: files,
-		}
+  it('hides the sidebar log types that dont have files in them', () => {
+    const state: Partial<SleuthState> = {
+      processedLogFiles: files,
+    };
 
-		const mergedFilesStatus: MergedFilesLoadStatus = {
-			all: true,
-			browser: false,
-			webapp: false,
-			mobile: false
-		}
+    const mergedFilesStatus: MergedFilesLoadStatus = {
+      all: true,
+      browser: false,
+      webapp: false,
+      mobile: false,
+    };
 
-		const selectedLogFileName: string = 'trace'
+    const selectedLogFileName = 'trace';
 
-		render(<Sidebar mergedFilesStatus={mergedFilesStatus} selectedLogFileName={selectedLogFileName} state={state as SleuthState} />)
+    render(
+      <Sidebar
+        mergedFilesStatus={mergedFilesStatus}
+        selectedLogFileName={selectedLogFileName}
+        state={state as SleuthState}
+      />,
+    );
 
-		const chromium = screen.getAllByText('Chromium')
-		expect(chromium).toHaveLength(1)
+    const chromium = screen.getAllByText('Chromium');
+    expect(chromium).toHaveLength(1);
 
-		const webapp = screen.getAllByText('WebApp')
-		expect(webapp).toHaveLength(1)
+    const webapp = screen.getAllByText('WebApp');
+    expect(webapp).toHaveLength(1);
 
-		const browser = screen.getAllByText('Browser Process')
-		expect(browser).toHaveLength(1)
+    const browser = screen.getAllByText('Browser Process');
+    expect(browser).toHaveLength(1);
 
-		const all = screen.getAllByText('All Desktop Logs')
-		expect(all).toHaveLength(1)
+    const all = screen.getAllByText('All Desktop Logs');
+    expect(all).toHaveLength(1);
 
-		const mobile = screen.queryByText('Mobile')
-		expect(mobile).not.toBeInTheDocument
+    const mobile = screen.queryByText('Mobile');
+    expect(mobile).not.toBeInTheDocument;
 
-		const installer = screen.queryByText('Installer')
-		expect(installer).not.toBeInTheDocument
-	});
-})
+    const installer = screen.queryByText('Installer');
+    expect(installer).not.toBeInTheDocument;
+  });
+});

--- a/test/renderer/rtl-new/sidebar.test.tsx
+++ b/test/renderer/rtl-new/sidebar.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Sidebar } from "../../../src/renderer/components/sidebar"
+import { render, screen } from '@testing-library/react'
+import { SleuthState } from "../../../src/renderer/state/sleuth";
+import { ProcessedLogFile, ProcessedLogFiles, LogType, MergedFilesLoadStatus } from "../../../src/interfaces";
+import { fakeUnzippedFile } from '../../__mocks__/unzipped-file';
+
+jest.mock('electron')
+
+const fakeFile1: ProcessedLogFile = {
+	repeatedCounts: {},
+	id: '123',
+	logEntries: [],
+	logFile: fakeUnzippedFile,
+	logType: LogType.BROWSER,
+	type: 'ProcessedLogFile',
+	levelCounts: {},
+  };
+
+const fakeFile2: ProcessedLogFile = {
+	repeatedCounts: {},
+	id: '1234',
+	logEntries: [],
+	logFile: fakeUnzippedFile,
+	logType: LogType.CHROMIUM,
+	type: 'ProcessedLogFile',
+	levelCounts: {}
+}
+
+const fakeFile3: ProcessedLogFile = {
+	repeatedCounts: {},
+	id: '12345',
+	logEntries: [],
+	logFile: fakeUnzippedFile,
+	logType: LogType.WEBAPP,
+	type: 'ProcessedLogFile',
+	levelCounts: {}
+}
+  
+  const files: ProcessedLogFiles = {
+	browser: [fakeFile1],
+	webapp: [fakeFile3],
+	state: [],
+	netlog: [],
+	installer: [],
+	trace: [],
+	mobile: [],
+	chromium: [fakeFile2],
+  };
+
+describe('sidebar', () => {
+	it('hides the sidebar log types that dont have files in them', () => {
+		const state: Partial<SleuthState> = {
+			processedLogFiles: files,
+		}
+
+		const mergedFilesStatus: MergedFilesLoadStatus = {
+			all: true,
+			browser: false,
+			webapp: false,
+			mobile: false
+		}
+
+		const selectedLogFileName: string = 'trace'
+
+		render(<Sidebar mergedFilesStatus={mergedFilesStatus} selectedLogFileName={selectedLogFileName} state={state as SleuthState} />)
+
+		const chromium = screen.getAllByText('Chromium')
+		expect(chromium).toHaveLength(1)
+
+		const webapp = screen.getAllByText('WebApp')
+		expect(webapp).toHaveLength(1)
+
+		const browser = screen.getAllByText('Browser Process')
+		expect(browser).toHaveLength(1)
+
+		const all = screen.getAllByText('All Desktop Logs')
+		expect(all).toHaveLength(1)
+
+		const mobile = screen.queryByText('Mobile')
+		expect(mobile).not.toBeInTheDocument
+
+		const installer = screen.queryByText('Installer')
+		expect(installer).not.toBeInTheDocument
+	});
+})


### PR DESCRIPTION
## Description

Sleuth currently shows all categories in the sidebar, regardless of if they have any files in them. This can be seen as bad UI due to them being clickable but doing nothing since no files appear under them. 

This PR solves this problem by hiding any category that has no files under them, resulting in cleaner and less cluttered UI. Also added tests to make ensure it hides the correct categories.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
  
https://github.com/tinyspeck/sleuth/assets/52749324/ee102bb6-f93f-4268-83a0-6ca836b1d95d
  
</td>
<td>

<img width="301" alt="Screenshot 2023-08-01 at 10 49 40 AM" src="https://github.com/tinyspeck/sleuth/assets/52749324/d15c20d5-5213-44da-b389-f034c63da761">

</td>
</tr>
</table>


fixes #118 