### PR TITLE
chore: remove looking for 'slack-' files + html

### DIFF
--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -259,7 +259,7 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
     const isSelected = selectedLogFileName === file.fileName;
 
     let label;
-    if (file.fileName.endsWith('gpu-log.html')) {
+    if (file.fileName.endsWith('gpu-info.json')) {
       label = 'GPU';
     } else if (file.fileName.endsWith('notification-warnings.json')) {
       label = 'Notification Warnings';
@@ -269,9 +269,18 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       label = 'Local Settings';
     } else if (file.fileName.endsWith('.trace')) {
       label = 'Performance Profile';
+    } else if (file.fileName.endsWith('root-state.json')) {
+      label = 'Root State';
+    } else if (file.fileName.endsWith('external-config.json')) {
+      label = 'External Config';
+    } else if (file.fileName.endsWith('logfiles-shipping-manifest.json')) {
+      label = 'Log Manifest';
+    } else if (file.fileName.endsWith('log-context.json')) {
+      label = 'Log Context';
+    } else if (file.fileName.endsWith('installation')) {
+      label = 'Installation';
     } else {
-      const nameMatch = file.fileName.match(/slack-(\w*)/);
-      label = nameMatch && nameMatch.length > 1 ? nameMatch[1] : file.fileName;
+      label = file.fileName;
     }
 
     const options: Partial<ITreeNode> = {

--- a/src/renderer/components/state-table.tsx
+++ b/src/renderer/components/state-table.tsx
@@ -29,7 +29,6 @@ export interface StateTableState<T extends keyof StateData> {
 
 export enum StateType {
   'settings',
-  'html',
   'notifs',
   'installation',
   'environment',
@@ -109,10 +108,6 @@ export class StateTable extends React.Component<
       throw new Error('StateTable: No file');
     }
 
-    if (this.isHtmlFile(selectedLogFile)) {
-      return StateType.html;
-    }
-
     if (this.isNotifsFile(selectedLogFile)) {
       return StateType.notifs;
     }
@@ -129,11 +124,7 @@ export class StateTable extends React.Component<
       return StateType.localSettings;
     }
 
-    const nameMatch = selectedLogFile.fileName.match(/slack-(\w*)/);
-    const type =
-      nameMatch && nameMatch.length > 1 ? nameMatch[1] : StateType.unknown;
-
-    return type as unknown as StateType;
+    return StateType.unknown;
   }
 
   private async parse(file: UnzippedFile) {
@@ -143,9 +134,7 @@ export class StateTable extends React.Component<
 
     d(`Reading ${file.fullPath}`);
 
-    if (this.isHtmlFile(file)) {
-      this.setState({ data: undefined, path: file.fullPath });
-    } else if (this.isInstallationFile(file)) {
+    if (this.isInstallationFile(file)) {
       try {
         const content = await fs.readFile(file.fullPath, 'utf8');
         this.setState({ data: [content], path: undefined });
@@ -245,10 +234,6 @@ export class StateTable extends React.Component<
   private isStateFile(file?: SelectableLogFile): file is UnzippedFile {
     const _file = file as UnzippedFile;
     return !!_file.fullPath;
-  }
-
-  private isHtmlFile(file: UnzippedFile) {
-    return file.fullPath.endsWith('.html');
   }
 
   private isNotifsFile(file: UnzippedFile) {


### PR DESCRIPTION
## Description

Due to files starting with the prefix '`slack-'` and html files no longer existing, removing support for them is the best option in terms of code cleanliness and efficiency.

## Notes
- Added labels for common state files that weren't accounted for