### PR TITLE
build: use semver regex for release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 anchors:
   job_filter_releases: &job_filter_releases
     tags:
-      only: /^v[0-9]+\.[0-9]+\.[0-9]+(-\w+)*$/
+      only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 parameters:
   build_image_tag_ubuntu:


### PR DESCRIPTION
See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string

The previous regex that we used had a faulty pre-release check that failed to match valid semver such as `v4.0.0-beta.1`.