### PR TITLE
refactor: cleaning improved search PR

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,6 +81,7 @@ export interface LogEntry {
   message: string;
   level: LogLevel;
   logType: LogType;
+  highlightMessage?: JSX.Element | undefined;
   line: number;
   sourceFile: string;
   meta?: string | LogEntry;

--- a/src/renderer/analytics/highlight-search-results.tsx
+++ b/src/renderer/analytics/highlight-search-results.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import Fuse from 'fuse.js';
 import { LogEntry } from 'src/interfaces';
 
-export function highlight(fuseSearchResult: any) {
+export function highlight(fuseSearchResult: Fuse.FuseResult<LogEntry>[]) {
   const highlightMatches = (
     inputText: string,
-    regions: [number, number][] = [],
+    regions: readonly [number, number][] = [],
   ) => {
     const children: React.ReactNode[] = [];
     let nextUnhighlightedRegionStartingIndex = 0;
@@ -46,11 +46,12 @@ export function highlight(fuseSearchResult: any) {
       const highlightedItem = { ...item };
 
       if (matches) {
-        matches.forEach((match: any) => {
-          highlightedItem.highlightMessage = highlightMatches(
-            match.value,
-            match.indices,
-          );
+        matches.forEach((match: Fuse.FuseResultMatch) => {
+          if (match.value && match.indices)
+            highlightedItem.highlightMessage = highlightMatches(
+              match.value,
+              match.indices,
+            );
         });
       }
       return highlightedItem;

--- a/src/renderer/analytics/highlight-search-results.tsx
+++ b/src/renderer/analytics/highlight-search-results.tsx
@@ -1,16 +1,6 @@
 import React from 'react';
 
 export function highlight(fuseSearchResult: any) {
-  const set = (obj: any, path: string, value: JSX.Element) => {
-    const pathValue = path.split('.');
-    let i;
-
-    for (i = 0; i < pathValue.length - 1; i++) {
-      obj = obj[pathValue[i]];
-    }
-
-    obj[pathValue[i]] = value;
-  };
 
   const highlightMatches = (
     inputText: string,
@@ -55,13 +45,8 @@ export function highlight(fuseSearchResult: any) {
       highlightedItem.originalText = item.message;
 
       matches.forEach((match: any) => {
-        set(
-          highlightedItem,
-          match.key,
-          highlightMatches(match.value, match.indices),
-        );
+        highlightedItem.message = highlightMatches(match.value, match.indices)
       });
-
       return highlightedItem;
     });
 }

--- a/src/renderer/analytics/highlight-search-results.tsx
+++ b/src/renderer/analytics/highlight-search-results.tsx
@@ -39,9 +39,7 @@ export function highlight(fuseSearchResult: Fuse.FuseResult<LogEntry>[]) {
   };
 
   return fuseSearchResult
-    .filter(
-      ({ matches }: Fuse.FuseResult<LogEntry>) => matches && matches.length,
-    )
+    .filter(({ matches }: Fuse.FuseResult<LogEntry>) => Array.isArray(matches))
     .map(({ item, matches }: Fuse.FuseResult<LogEntry>) => {
       const highlightedItem = { ...item };
 

--- a/src/renderer/analytics/highlight-search-results.tsx
+++ b/src/renderer/analytics/highlight-search-results.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import Fuse from 'fuse.js';
+import { LogEntry } from 'src/interfaces';
 
 export function highlight(fuseSearchResult: any) {
-
   const highlightMatches = (
     inputText: string,
     regions: [number, number][] = [],
@@ -38,15 +39,20 @@ export function highlight(fuseSearchResult: any) {
   };
 
   return fuseSearchResult
-    .filter(({ matches }: any) => matches && matches.length)
-    .map(({ item, matches }: any) => {
+    .filter(
+      ({ matches }: Fuse.FuseResult<LogEntry>) => matches && matches.length,
+    )
+    .map(({ item, matches }: Fuse.FuseResult<LogEntry>) => {
       const highlightedItem = { ...item };
-      // Need to store originalText due to item.message being replaced with JSX element for styling highlights, this cannot be used for is-redux-action function in messageCellRenderer
-      highlightedItem.originalText = item.message;
 
-      matches.forEach((match: any) => {
-        highlightedItem.message = highlightMatches(match.value, match.indices)
-      });
+      if (matches) {
+        matches.forEach((match: any) => {
+          highlightedItem.highlightMessage = highlightMatches(
+            match.value,
+            match.indices,
+          );
+        });
+      }
       return highlightedItem;
     });
 }

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -581,6 +581,8 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
   private messageCellRenderer({
     rowData: entry,
   }: TableCellProps): JSX.Element | string {
+    const message = entry.highlightMessage ?? entry.message;
+
     if (entry && entry.meta) {
       const icon = isReduxAction(entry.message) ? (
         <Icon icon="diagram-tree" />
@@ -590,9 +592,7 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
       return (
         <div style={{ display: 'flex', gap: '0.25rem' }}>
           <span title={entry.message}>{icon}</span>
-          <span title={entry.message}>
-            {entry.highlightMessage ? entry.highlightMessage : entry.message}
-          </span>
+          <span title={entry.message}>{message}</span>
         </div>
       );
     } else if (entry && entry.repeated) {
@@ -611,13 +611,11 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
       return (
         <div style={{ display: 'flex', gap: '0.25rem' }}>
           <span>{emojiMessage}</span>
-          <span>
-            {entry.highlightMessage ? entry.highlightMessage : entry.message}
-          </span>
+          <span>{message}</span>
         </div>
       );
     } else {
-      return entry.highlightMessage ? entry.highlightMessage : entry.message;
+      return message;
     }
   }
 

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -582,26 +582,17 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
     rowData: entry,
   }: TableCellProps): JSX.Element | string {
     if (entry && entry.meta) {
-      let icon;
-      // When first loads up without search, originalText will not exist.
-      if (!entry.originalText && entry.message) {
-        icon = isReduxAction(entry.message) ? (
-          <Icon icon="diagram-tree" />
-        ) : (
-          <Icon icon="paperclip" />
-        );
-      } else if (entry.originalText) {
-        icon = isReduxAction(entry.originalText) ? (
-          <Icon icon="diagram-tree" />
-        ) : (
-          <Icon icon="paperclip" />
-        );
-      }
-
+      const icon = isReduxAction(entry.message) ? (
+        <Icon icon="diagram-tree" />
+      ) : (
+        <Icon icon="paperclip" />
+      );
       return (
         <div style={{ display: 'flex', gap: '0.25rem' }}>
           <span title={entry.message}>{icon}</span>
-          <span title={entry.message}>{entry.message}</span>
+          <span title={entry.message}>
+            {entry.highlightMessage ? entry.highlightMessage : entry.message}
+          </span>
         </div>
       );
     } else if (entry && entry.repeated) {
@@ -620,11 +611,13 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
       return (
         <div style={{ display: 'flex', gap: '0.25rem' }}>
           <span>{emojiMessage}</span>
-          <span>{entry.message}</span>
+          <span>
+            {entry.highlightMessage ? entry.highlightMessage : entry.message}
+          </span>
         </div>
       );
     } else {
-      return entry.message;
+      return entry.highlightMessage ? entry.highlightMessage : entry.message;
     }
   }
 


### PR DESCRIPTION
## Description

This PR refactors #124 by adding `types` to the `highlight` function as well as removing the `set` function within the `highlight` function. 

## Notes 
- Added `highlightMessage` to `LogEntry` interface which allows for the `messageCellRenderer` to behave more closely to it did prior to #124 and remove the need for `originalText` to exist.