### PR TITLE
fix: support longer ios filenames

### DIFF
--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -1058,7 +1058,7 @@ export function getMatchFunction(
   } else if (logType === LogType.MOBILE) {
     if (logFile.fileName.startsWith('attachment')) {
       return matchLineAndroid;
-    } else if (/(utf-8'')?Default_(.){0,14}(\.txt$)/.test(logFile.fileName)) {
+    } else if (/(utf-8'')?Default_(.){0,20}(\.txt$)/.test(logFile.fileName)) {
       return matchLineIOS;
     } else {
       return matchLineMobile;


### PR DESCRIPTION
- Increase filename length from 14 to 20 (after the `Default_`) to support filenames like `Default_logs-redacted (10).txt`

Reported here: https://slack-pde.slack.com/archives/C8EH27UDT/p1701113267842639