### PR TITLE
ci: load OIDC secrets into codesign job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,8 +207,8 @@ workflows:
             - build-macos-x64
           arch: x64
           filters:
-            # branches:
-            #   only: main
+            branches:
+              only: main
             <<: *job_filter_releases
       - code-sign-macos:
           name: code-sign-macos-arm64
@@ -216,8 +216,8 @@ workflows:
             - build-macos-arm64
           arch: arm64
           filters:
-            # branches:
-            #   only: main
+            branches:
+              only: main
             <<: *job_filter_releases
       - code-sign-macos:
           name: code-sign-macos-universal
@@ -225,8 +225,8 @@ workflows:
             - build-macos-universal
           arch: universal
           filters:
-            # branches:
-            #   only: main
+            branches:
+              only: main
             <<: *job_filter_releases
       - publish:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,11 @@ jobs:
       - attach_workspace:
           at: << parameters.artifact_dir >>
       - run:
+          name: Load OIDC Secrets
+          command: |
+            curl -X POST "$SLACK_SECRETS_SERVICE_ENDPOINT?format=shell" -H "TSAuth-Token: $SLACK_SECRETS_SERVICE_AUTHZ_TOKEN" -H "Content-Type: application/json" -d '{"token":"'$CIRCLE_OIDC_TOKEN'"}' >> $BASH_ENV
+      - run:
+          name: Code Sign Sleuth
           command: |
             mv << parameters.artifact_dir >>/make/zip/darwin/<< parameters.arch >>/*.zip << parameters.artifact_dir >>
             export JOB_PARAMS=$(

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,8 +207,8 @@ workflows:
             - build-macos-x64
           arch: x64
           filters:
-            branches:
-              only: main
+            # branches:
+            #   only: main
             <<: *job_filter_releases
       - code-sign-macos:
           name: code-sign-macos-arm64
@@ -216,8 +216,8 @@ workflows:
             - build-macos-arm64
           arch: arm64
           filters:
-            branches:
-              only: main
+            # branches:
+            #   only: main
             <<: *job_filter_releases
       - code-sign-macos:
           name: code-sign-macos-universal
@@ -225,8 +225,8 @@ workflows:
             - build-macos-universal
           arch: universal
           filters:
-            branches:
-              only: main
+            # branches:
+            #   only: main
             <<: *job_filter_releases
       - publish:
           requires:


### PR DESCRIPTION
Code signing now should work. Tested in commit [0e536b3](https://github.com/tinyspeck/sleuth/pull/132/commits/0e536b3bd512e051756a4ed722a785c6823d9049).