### PR TITLE
build: disable `hmr` in parcel

### DIFF
--- a/tools/parcel-build.js
+++ b/tools/parcel-build.js
@@ -30,8 +30,7 @@ async function compileParcel(options = {}) {
     //   key: './ssl/k.key' // path to custom key
     // },
     logLevel: 3, // 3 = log everything, 2 = log warnings & errors, 1 = log errors
-    hmr: true, //Enable or disable HMR while watching
-    hmrPort: 0, // The port the HMR socket runs on, defaults to a random free port (0 in node.js resolves to a random free port)
+    hmr: false, //Enable or disable HMR while watching
     sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
     hmrHostname: '', // A hostname for hot module reload, default to ''
     detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled,


### PR DESCRIPTION
Parcel attempts to use `hmr` flag even when `process.env.NODE_ENV=production` is set.

I took a look in `node_modules` and the implementation for the option looks like:

```js
const hmr = target === 'node' ? false : typeof options.hmr === 'boolean' ? options.hmr : watch;
```

Contrary to the code comment, it seems like the HMR server is started independently of the status of the `watch` flag:

```js
      if (_this3.options.watch) {
        _this3.watcher = new Watcher(); // Wait for ready event for reliable testing on watcher

        if (process.env.NODE_ENV === 'test' && !_this3.watcher.ready) {
          yield new Promise(resolve => _this3.watcher.once('ready', resolve));
        }

        _this3.watchedGlobs.forEach(glob => {
          _this3.watcher.add(glob);
        });

        _this3.watcher.on('add', _this3.onAdd.bind(_this3));

        _this3.watcher.on('change', _this3.onChange.bind(_this3));

        _this3.watcher.on('unlink', _this3.onUnlink.bind(_this3));
      }

      if (_this3.options.hmr) {
        _this3.hmr = new HMRServer();
        _this3.options.hmrPort = yield _this3.hmr.start(_this3.options);
      }
```

I don't think we have HMR set up in this project anyways, so this PR turns HMR off to avoid WebSocket errors in the prod build.