### PR TITLE
chore: stop hiding `/out/` in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,10 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "files.exclude": {
-    "**/.git": true,
-    "**/.svn": true,
-    "**/.hg": true,
     "**/.DS_Store": true,
-    "**/out": true,
+    "**/.git": true,
+    "**/.hg": true,
+    "**/.svn": true,
     "**/catapult": true
   },
   "typescript.tsdk": "node_modules/typescript/lib"


### PR DESCRIPTION
Not sure why we do this, it's a bit annoying when I want to quickly access the output of `yarn package`.