### PR TITLE
build: add universal code-sign macos job to dependency for publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,7 @@ workflows:
             - build-ubuntu
             - code-sign-macos-x64
             - code-sign-macos-arm64
+            - code-sign-macos-universal
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
The `publish` job now works but is suspiciously missing the universal asset