### PR TITLE
perf: don't filter and sort on entry change

### DIFF
--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -195,21 +195,18 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
     const rangeChanged = dateRange !== nextProps.dateRange;
     const nextRange = nextProps.dateRange;
 
-    // This should only happen if a bookmark was activated
     if (entryChanged) {
+      const selectedIndex = this.findIndexForSelectedEntry(
+        this.state.sortedList,
+      );
       this.setState({
         selectedEntry: this.props.state.selectedEntry,
+        selectedIndex,
         scrollToSelection: true,
       });
     }
 
-    if (
-      filterChanged ||
-      searchChanged ||
-      fileChanged ||
-      rangeChanged ||
-      entryChanged
-    ) {
+    if (filterChanged || searchChanged || fileChanged || rangeChanged) {
       const sortOptions: SortFilterListOptions = {
         showOnlySearchResults: nextShowOnlySearchResults,
         filter: nextLevelFilter,


### PR DESCRIPTION
Seems this code has been here for a long time, but we used to re-run the sort and filter algorithm each time we click on an entry to select it.

This seems unnecessary, so this PR removes that while still properly updating the `selectedIndex` variable whenever the entry changes.