### PR TITLE
feat(log-table): tag process types when viewing All Desktop Logs

### DIFF
--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -16,7 +16,13 @@ import {
 import { Icon } from '@blueprintjs/core';
 import debug from 'debug';
 
-import { LevelFilter, LogEntry, DateRange } from '../../interfaces';
+import {
+  LevelFilter,
+  LogEntry,
+  DateRange,
+  LogType,
+  ProcessableLogType,
+} from '../../interfaces';
 import { didFilterChange } from '../../utils/did-filter-change';
 import { isReduxAction } from '../../utils/is-redux-action';
 import {
@@ -31,6 +37,7 @@ import { between } from '../../utils/is-between';
 import { getRangeEntries } from '../../utils/get-range-from-array';
 import { RepeatedLevels } from '../../shared-constants';
 import { reaction } from 'mobx';
+import { Tag } from 'antd';
 
 const d = debug('sleuth:logtable');
 
@@ -722,7 +729,7 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
   private renderTable(options: Size): JSX.Element {
     const { sortedList, selectedIndex, ignoreSearchIndex, scrollToSelection } =
       this.state;
-    const { searchIndex, searchList } = this.props;
+    const { logFile, searchIndex, searchList } = this.props;
 
     const tableOptions: TableProps = {
       ...options,
@@ -735,6 +742,14 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
       sort: this.onSortChange,
       sortBy: this.state.sortBy,
       sortDirection: this.state.sortDirection,
+    };
+
+    const colorMap: Record<ProcessableLogType, string> = {
+      [LogType.BROWSER]: 'cyan',
+      [LogType.WEBAPP]: 'magenta',
+      [LogType.INSTALLER]: 'green',
+      [LogType.CHROMIUM]: 'geekblue',
+      [LogType.MOBILE]: 'lime',
     };
 
     if (scrollToSelection) tableOptions.scrollToIndex = selectedIndex;
@@ -759,6 +774,20 @@ export class LogTable extends React.Component<LogTableProps, LogTableState> {
           flexGrow={2}
         />
         <Column label="Level" dataKey="level" width={100} />
+        {logFile.logType === LogType.ALL ? (
+          <Column
+            label="Process"
+            dataKey="logType"
+            width={120}
+            cellRenderer={({ cellData }: TableCellProps) => (
+              <Tag
+                color={colorMap[cellData as ProcessableLogType] ?? 'default'}
+              >
+                {cellData}
+              </Tag>
+            )}
+          />
+        ) : null}
         <Column
           label="Message"
           dataKey="message"


### PR DESCRIPTION
<img width="1406" alt="image" src="https://github.com/tinyspeck/sleuth/assets/16010076/c98455c6-9b42-4951-8b4f-45e80a78c47f">

I think this will be useful!