### PR TITLE
chore: update devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "date-fns": "^2.16.1",
     "debounce": "^1.2.0",
     "debug": "4.3.1",
-    "devtools-frontend-prebuilt": "^1.0.1",
+    "devtools-frontend-prebuilt": "1.2.0-beta1",
     "electron-context-menu": "2.3.0",
     "electron-devtools-installer": "3.2.0",
     "electron-squirrel-startup": "1.0.0",

--- a/src/main/scheme.ts
+++ b/src/main/scheme.ts
@@ -1,4 +1,5 @@
 import { normalize, join, relative } from 'path';
+import { pathToFileURL } from 'url';
 import { net, protocol } from 'electron';
 
 export function registerSchemePrivilege() {
@@ -28,7 +29,7 @@ export function registerScheme() {
       // request appears to be try to be navigating outside of dist
       return new Response(null, { status: 400 });
     } else {
-      return net.fetch(`file://${path}`);
+      return net.fetch(pathToFileURL(path).href);
     }
   });
 }

--- a/src/main/scheme.ts
+++ b/src/main/scheme.ts
@@ -1,9 +1,9 @@
 import { normalize, join, relative } from 'path';
-import { protocol } from 'electron';
+import { net, protocol } from 'electron';
 
 export function registerSchemePrivilege() {
   protocol.registerSchemesAsPrivileged([
-    { scheme: 'oop', privileges: { standard: true } },
+    { scheme: 'oop', privileges: { standard: true, supportFetchAPI: true } },
   ]);
 }
 
@@ -13,11 +13,11 @@ export function registerSchemePrivilege() {
  * protecting against Sleuth freezes
  */
 export function registerScheme() {
-  protocol.registerFileProtocol('oop', (request, callback) => {
+  protocol.handle('oop', (request) => {
     const url = new URL(request.url);
     if (url.host !== 'oop') {
       // request did not match known path, cowardly refusing
-      callback('Not found');
+      return new Response(null, { status: 400 });
     }
 
     const dist = normalize(`${__dirname}/../..`);
@@ -26,9 +26,9 @@ export function registerScheme() {
     const relation = relative(dist, path);
     if (relation.includes('..')) {
       // request appears to be try to be navigating outside of dist
-      callback('Not found');
+      return new Response(null, { status: 400 });
     } else {
-      callback({ path });
+      return net.fetch(`file://${path}`);
     }
   });
 }

--- a/src/renderer/processor/interfaces.ts
+++ b/src/renderer/processor/interfaces.ts
@@ -21,6 +21,7 @@ export interface ChromiumTrace {
 
 export interface ThreadNameEvent {
   name: 'thread_name';
+  cat?: string;
   args?: {
     name?: string;
   };

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -141,8 +141,15 @@ export class TraceProcessor {
     if (trace) {
       const { traceEvents: events } = trace;
       return events.reduce<number>((earliest, entry) => {
-        const { ts } = entry;
-        return ts > 0 && ts < earliest ? ts : earliest;
+        const { ts, cat } = entry;
+
+        // Blink events include the time that the app started. If a trace is
+        // performed at a later time, it creates a skewed timeline with blank
+        // space at the beginning.
+        const isBlinkEvent = cat?.startsWith('blink');
+        const isEarlier = ts > 0 && ts < earliest;
+
+        return isEarlier && !isBlinkEvent ? ts : earliest;
       }, Number.MAX_SAFE_INTEGER);
     }
     return 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,10 +5276,10 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-devtools-frontend-prebuilt@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/devtools-frontend-prebuilt/-/devtools-frontend-prebuilt-1.1.0.tgz#eb94f823e17288225db3b07f85042b7ff040e58c"
-  integrity sha512-SVedUtM2ecf40t68c5csgW/qkpGcA98Yz3DVoS0OKkX0GUZ5gNskiQvjqf6699vjGaPtidhvuKWKcPv2P4+cSQ==
+devtools-frontend-prebuilt@1.2.0-beta1:
+  version "1.2.0-beta1"
+  resolved "https://registry.yarnpkg.com/devtools-frontend-prebuilt/-/devtools-frontend-prebuilt-1.2.0-beta1.tgz#2cbd8022ff913654a18f6844fb715bd87fc2acef"
+  integrity sha512-Ewkzlrn/jK4IjMblquaWBqvoSS8WSI6Dx8T2SEwAcSXnEVogrbnHvYIx02BVTeKW+9W9jsqjwNJb82rZKK8vdA==
 
 diff-sequences@^27.4.0:
   version "27.4.0"


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="2032" alt="Screenshot 2024-05-17 at 6 44 54 PM" src="https://github.com/tinyspeck/sleuth/assets/1656324/68d3caf5-ff62-4e45-83d6-6f87352230c4"> | <img width="2032" alt="Screenshot 2024-05-17 at 6 45 44 PM" src="https://github.com/tinyspeck/sleuth/assets/1656324/254c8479-f8c2-4cd8-bec4-c8de58efda0b"> |

- Fit timeline to trace start time rather than app start time 0af6880476222c826c7845d1c8a7d10ad0263f84
- Update chrome devtools frontend 79b158beeab498c0a282956c22e5e5e22c72385f
- Migrate `oop://` to new handler API 3ef3ad08b66eb1e42919e1fe19570a3ce1fcd59c