### PR TITLE
feat: show browser process in performance profile view

### DIFF
--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -75,7 +75,6 @@ export class DevtoolsView extends React.Component<
   private renderThreads() {
     const { traceThreads } = this.props.state;
     const hasThreads = !!traceThreads?.length;
-    const missingThreads = traceThreads?.length === 0;
     const isLoading = !traceThreads;
     const startTime = parseInt(
       this.props.file.fileName.split('.')[0]?.split('_')[4] || '0',
@@ -108,7 +107,7 @@ export class DevtoolsView extends React.Component<
           <tbody>
             {hasThreads &&
               traceThreads?.map((thread) => this.rowRenderer(thread))}
-            {missingThreads && (
+            {!hasThreads && (
               <tr>
                 <td colSpan={3}>No renderer threads found</td>
               </tr>

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -16,6 +16,7 @@ export interface DevtoolsViewProps {
 
 export interface DevtoolsViewState {
   profilePid?: number;
+  profileType?: TraceThreadDescription['type'];
 }
 
 const d = debug('sleuth:devtoolsview');
@@ -43,7 +44,7 @@ export class DevtoolsView extends React.Component<
     }
   }
 
-  private rowRenderer({ title, processId, isClient }: TraceThreadDescription) {
+  private rowRenderer({ title, type, processId, isClient }: TraceThreadDescription) {
     return (
       <tr>
         <td>
@@ -53,7 +54,7 @@ export class DevtoolsView extends React.Component<
         <td>
           <ButtonGroup fill={true}>
             <Button
-              onClick={() => this.setState({ profilePid: processId })}
+              onClick={() => this.setState({ profilePid: processId, profileType: type })}
               icon={'document-open'}
             >
               Open

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -44,7 +44,12 @@ export class DevtoolsView extends React.Component<
     }
   }
 
-  private rowRenderer({ title, type, processId, isClient }: TraceThreadDescription) {
+  private rowRenderer({
+    title,
+    type,
+    processId,
+    isClient,
+  }: TraceThreadDescription) {
     return (
       <tr>
         <td>
@@ -54,7 +59,9 @@ export class DevtoolsView extends React.Component<
         <td>
           <ButtonGroup fill={true}>
             <Button
-              onClick={() => this.setState({ profilePid: processId, profileType: type })}
+              onClick={() =>
+                this.setState({ profilePid: processId, profileType: type })
+              }
               icon={'document-open'}
             >
               Open

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -5,7 +5,7 @@ import { HTMLTable, Button, Card, Icon, ButtonGroup } from '@blueprintjs/core';
 import { SleuthState } from '../state/sleuth';
 import { autorun, IReactionDisposer } from 'mobx';
 import { UnzippedFile } from '../../interfaces';
-import { RendererDescription, TraceProcessor } from '../processor/trace';
+import { TraceThreadDescription, TraceProcessor } from '../processor/trace';
 import autoBind from 'react-autobind';
 import debug from 'debug';
 
@@ -38,12 +38,12 @@ export class DevtoolsView extends React.Component<
 
   async prepare() {
     const { state } = this.props;
-    if (!state.rendererThreads) {
-      state.rendererThreads = await this.processor.getRendererProcesses();
+    if (!state.traceThreads) {
+      state.traceThreads = await this.processor.getProcesses();
     }
   }
 
-  private rowRenderer({ title, processId, isClient }: RendererDescription) {
+  private rowRenderer({ title, processId, isClient }: TraceThreadDescription) {
     return (
       <tr>
         <td>
@@ -64,6 +64,58 @@ export class DevtoolsView extends React.Component<
     );
   }
 
+  private renderThreads() {
+    const { traceThreads } = this.props.state;
+    const hasThreads = !!traceThreads?.length;
+    const missingThreads = traceThreads?.length === 0;
+    const isLoading = !traceThreads;
+    const startTime = parseInt(
+      this.props.file.fileName.split('.')[0]?.split('_')[4] || '0',
+      10,
+    );
+    const endTime = parseInt(
+      this.props.file.fileName.split('.')[0]?.split('_')[0] || '0',
+      10,
+    );
+    const duration = endTime - startTime;
+
+    return (
+      <Card>
+        <h1>Threads</h1>
+        <h4>
+          Duration:{' '}
+          {duration ? Math.floor(duration / 1000).toString() : 'unknown'}{' '}
+          seconds | Trace started:{' '}
+          {startTime ? new Date(startTime).toLocaleString() : 'unknown'} | Trace
+          ended: {endTime ? new Date(endTime).toLocaleString() : 'unknown'}
+        </h4>
+        <h5>* Start & end times displayed in your local time</h5>
+        <HTMLTable>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>PID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hasThreads &&
+              traceThreads?.map((thread) => this.rowRenderer(thread))}
+            {missingThreads && (
+              <tr>
+                <td colSpan={3}>No renderer threads found</td>
+              </tr>
+            )}
+            {isLoading && (
+              <tr>
+                <td colSpan={3}>Loading...</td>
+              </tr>
+            )}
+          </tbody>
+        </HTMLTable>
+      </Card>
+    );
+  }
+
   public render() {
     if (this.state.profilePid) {
       return (
@@ -77,58 +129,7 @@ export class DevtoolsView extends React.Component<
       );
     }
 
-    const { rendererThreads } = this.props.state;
-    const hasThreads = !!rendererThreads?.length;
-    const missingThreads = rendererThreads?.length === 0;
-    const isLoading = !rendererThreads;
-    const startTime = parseInt(
-      this.props.file.fileName.split('.')[0]?.split('_')[4] || '0',
-      10,
-    );
-    const endTime = parseInt(
-      this.props.file.fileName.split('.')[0]?.split('_')[0] || '0',
-      10,
-    );
-    const duration = endTime - startTime;
-
-    return (
-      <div className="ProcessTable">
-        <Card>
-          <h1>Renderer Threads</h1>
-          <h4>
-            Duration:{' '}
-            {duration ? Math.floor(duration / 1000).toString() : 'unknown'}{' '}
-            seconds | Trace started:{' '}
-            {startTime ? new Date(startTime).toLocaleString() : 'unknown'} |
-            Trace ended:{' '}
-            {endTime ? new Date(endTime).toLocaleString() : 'unknown'}
-          </h4>
-          <h5>* Start & end times displayed in your local time</h5>
-          <HTMLTable>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>PID</th>
-              </tr>
-            </thead>
-            <tbody>
-              {hasThreads &&
-                rendererThreads?.map((thread) => this.rowRenderer(thread))}
-              {missingThreads && (
-                <tr>
-                  <td colSpan={3}>No renderer threads found</td>
-                </tr>
-              )}
-              {isLoading && (
-                <tr>
-                  <td colSpan={3}>Loading...</td>
-                </tr>
-              )}
-            </tbody>
-          </HTMLTable>
-        </Card>
-      </div>
-    );
+    return <div className="ProcessTable">{this.renderThreads()}</div>;
   }
 
   public componentWillUnmount() {

--- a/src/renderer/processor/interfaces.ts
+++ b/src/renderer/processor/interfaces.ts
@@ -30,17 +30,20 @@ export interface ThreadNameEvent {
   ts: number;
 }
 
-export interface RendererThread {
+export interface TraceThread {
+  isClient: boolean;
+  title?: string;
+}
+
+export interface RendererThread extends TraceThread {
   data: {
     frame: string;
     url: string;
     processId: number;
   };
-  isClient: boolean;
-  title?: string;
 }
 
-export interface BrowserThread {
+export interface BrowserThread extends TraceThread {
   pid: number;
   tid: number;
   ts: number;

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -9,13 +9,12 @@ import type {
   ThreadInfo,
   BrowserThread,
   RendererThread,
+  TraceThread,
 } from './interfaces';
 
 const d = debug('sleuth:trace-processor');
-export interface TraceThreadDescription {
-  title?: string;
+export interface TraceThreadDescription extends TraceThread {
   type: 'browser' | 'renderer';
-  isClient: boolean;
   processId: number;
 }
 

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -41,7 +41,6 @@ export class TraceProcessor {
       const raw = fs.readFileSync(this.file.fullPath, 'utf8');
       const json = JSON.parse(raw);
       if (json.traceEvents) {
-        console.log('***getTrace', json);
         return json;
       }
     } catch (e) {

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -218,7 +218,7 @@ export class TraceProcessor {
       if (initialEntry) {
         return [initialEntry, ...events];
       } else if (pid) {
-        return events.filter(e => e.pid === pid);
+        return events.filter((e) => e.pid === pid);
       } else {
         return events;
       }

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -12,8 +12,9 @@ import type {
 } from './interfaces';
 
 const d = debug('sleuth:trace-processor');
-export interface RendererDescription {
+export interface TraceThreadDescription {
   title?: string;
+  type: 'browser' | 'renderer';
   isClient: boolean;
   processId: number;
 }
@@ -131,6 +132,7 @@ export class TraceProcessor {
       ) as Array<ThreadNameEvent>;
       const browser = await this.getBrowserThread(threads);
       const renderers = await this.getRendererThreads(events, threads);
+      console.trace(`***getThreadInfo`, ({ browser, renderers }));
       return { browser, renderers };
     }
     return { renderers: [] };
@@ -160,18 +162,28 @@ export class TraceProcessor {
     return trace?.traceEvents;
   }
 
-  async getRendererProcesses(): Promise<
-    Array<RendererDescription> | undefined
+  async getProcesses(): Promise<
+    Array<TraceThreadDescription> | undefined
   > {
-    const { renderers } = await this.getThreadInfo();
-    return renderers.map(({ data, isClient, title }) => {
-      const { processId } = data;
-      return {
+    const { browser, renderers } = await this.getThreadInfo();
+    const threads: Array<TraceThreadDescription> = [];
+    if (browser) {
+      threads.push({
+        title: 'Main process',
+        type: 'browser',
+        isClient: false,
+        processId: browser.pid
+      });
+    }
+    for (const { data, isClient, title } of renderers) {
+      threads.push({
         title,
+        type: 'renderer',
         isClient,
-        processId,
-      };
-    });
+        processId: data.processId,
+      })
+    }
+    return threads;
   }
 
   async makeInitialEntry(

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -36,7 +36,7 @@ import { changeIcon } from '../ipc';
 import { ICON_NAMES } from '../../shared-constants';
 import { IpcEvents } from '../../ipc-events';
 import { setupTouchBarAutoruns } from './touchbar';
-import { RendererDescription } from '../processor/trace';
+import { TraceThreadDescription } from '../processor/trace';
 
 const d = debug('sleuth:state');
 
@@ -96,7 +96,7 @@ export class SleuthState {
     { parse: true, fallback: {} },
   );
   // ** Profiler **
-  @observable public rendererThreads: Array<RendererDescription> | undefined;
+  @observable public traceThreads?: Array<TraceThreadDescription>;
 
   // ** Settings **
   @observable public isDarkMode = !!this.retrieve<boolean>('isDarkMode', {
@@ -319,7 +319,7 @@ export class SleuthState {
     this.cachePath = undefined;
     this.selectedCacheKey = undefined;
     this.isLoadingCacheKeys = false;
-    this.rendererThreads = undefined;
+    this.traceThreads = undefined;
 
     if (goBackToHome) {
       this.resetApp();


### PR DESCRIPTION
_this is a non-fork branched PR based on #153_

- Changes "Renderer Threads" to "Threads"
- Shows main process thread first

| Before | After |
| --- | --- |
| <img width="1282" alt="Screenshot 2024-05-16 at 6 58 10 PM" src="https://github.com/tinyspeck/sleuth/assets/1656324/d1334bf8-9ad2-4e4b-9ca6-4a16bb69572c"> | <img width="1282" alt="Screenshot 2024-05-16 at 6 57 37 PM" src="https://github.com/tinyspeck/sleuth/assets/1656324/903ada18-bf46-4006-a57e-262a9a45f306"> |
| No main process trace explorer 😭 | <img width="1282" alt="Screenshot 2024-05-16 at 7 02 25 PM" src="https://github.com/tinyspeck/sleuth/assets/1656324/28a1e8f1-1fa4-4ca5-883e-0aa2a2f677b4"> |
