### PR TITLE
feat: warn when user is running Slack from mounted DMG

### DIFF
--- a/src/renderer/analytics/environment-analytics.tsx
+++ b/src/renderer/analytics/environment-analytics.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { getOSInfo, getVersionInfo } from '../../utils/settings-data-helper';
 import { getChannelInfo } from './settings-analytics';
+import { UnzippedFile } from '../../interfaces';
+import { readJsonFile } from '../../renderer/analytics/read-json-file';
 
 export function getEnvInfo(data: any): Array<JSX.Element> {
   const result: Array<JSX.Element> = [];
@@ -17,4 +19,23 @@ export function getEnvInfo(data: any): Array<JSX.Element> {
 
 function getGPUComposition({ isGpuCompositionAvailable }: any): string {
   return isGpuCompositionAvailable === true ? 'available' : 'unavailable';
+}
+
+/**
+ * If `environment.json` has any red flags, point them out in the sidebar
+ * via warnings. This function should be used in `src/components/sidebar.tsx`.
+ * @param file
+ */
+export function getEnvironmentWarnings(file: UnzippedFile) {
+  const data = readJsonFile(file);
+  const result: Array<string> = [];
+
+  if (
+    typeof data?.resourcePath === 'string' &&
+    data.resourcePath.startsWith(`/Volumes/`)
+  ) {
+    result.push(`Slack.app resources are being run from ${data.resourcePath}`);
+  }
+
+  return result;
 }

--- a/src/renderer/components/sidebar.tsx
+++ b/src/renderer/components/sidebar.tsx
@@ -25,6 +25,7 @@ import { countExcessiveRepeats } from '../../utils/count-excessive-repeats';
 import { plural } from '../../utils/pluralize';
 import { getRootStateWarnings } from '../analytics/root-state-analytics';
 import { getTraceWarnings } from '../analytics/trace-analytics';
+import { getEnvironmentWarnings } from '../analytics/environment-analytics';
 
 export interface SidebarProps {
   selectedLogFileName: string;
@@ -390,6 +391,23 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
     if (file.fileName.endsWith('.trace')) {
       const warnings = getTraceWarnings(file);
       if (warnings && warnings.length > 0) {
+        const content = warnings.join('\n');
+        return (
+          <Tooltip
+            content={content}
+            position={Position.RIGHT}
+            boundary="viewport"
+          >
+            <Icon icon="error" intent={Intent.WARNING} />
+          </Tooltip>
+        );
+      }
+    }
+
+    // TODO: refactor this rendering code probably
+    if (file.fileName.endsWith('environment.json')) {
+      const warnings = getEnvironmentWarnings(file);
+      if (warnings.length > 0) {
         const content = warnings.join('\n');
         return (
           <Tooltip


### PR DESCRIPTION
Performance issues may arise on macOS if a user installs `Slack.dmg` but keeps running the app from the mounted volume rather than installing their app into `/Applications`.

This PR adds a sidebar warning whenever this is the case.