### PR TITLE
ci: add `sleuth-code-signing` context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,8 @@ workflows:
             branches:
               only: main
             <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
       - code-sign-macos:
           name: code-sign-macos-arm64
           requires:
@@ -223,6 +225,8 @@ workflows:
             branches:
               only: main
             <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
       - code-sign-macos:
           name: code-sign-macos-universal
           requires:
@@ -232,6 +236,8 @@ workflows:
             branches:
               only: main
             <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
       - publish:
           requires:
             - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ workflows:
             - build-macos-arm64
           arch: arm64
           filters:
-            branches:
-              only: main
+            # branches:
+            #   only: main
             <<: *job_filter_releases
           context:
             - sleuth-code-signing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ workflows:
             - build-macos-arm64
           arch: arm64
           filters:
-            # branches:
-            #   only: main
+            branches:
+              only: main
             <<: *job_filter_releases
           context:
             - sleuth-code-signing


### PR DESCRIPTION
Adds the correct environment variable context to pull the code-sign runner's entrypoint code.

See [successful run](https://app.circleci.com/pipelines/github/tinyspeck/sleuth/594/workflows/c4cfdce1-33ec-4433-a473-f4bdd94ff55f/jobs/3630) on commit 114584d.
