### PR TITLE
fix: support new mobile timestamp format

### DIFF
--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -192,6 +192,10 @@ export function getTypeForFile(
   } else if (
     fileName.startsWith('Default_') ||
     fileName.startsWith('attachment') ||
+    fileName.startsWith('MainAppLog') ||
+    fileName.startsWith('NotificationExtension') ||
+    fileName.startsWith('ShareExtension') ||
+    fileName.startsWith('WidgetLog') ||
     /\w{9,}_\w{9,}_\d{16,}\.txt/.test(fileName)
   ) {
     return LogType.MOBILE;

--- a/src/renderer/processor.ts
+++ b/src/renderer/processor.ts
@@ -1081,13 +1081,7 @@ export function getMatchFunction(
       return matchLineShipItMac;
     }
   } else if (logType === LogType.MOBILE) {
-    if (logFile.fileName.startsWith('attachment')) {
-      return matchLineAndroid;
-    } else if (/(utf-8'')?Default_(.){0,20}(\.txt$)/.test(logFile.fileName)) {
-      return matchLineIOS;
-    } else {
-      return matchLineMobile;
-    }
+    return matchLineMobile;
   } else if (logType === LogType.CHROMIUM) {
     return matchLineChromium;
   } else {


### PR DESCRIPTION
Mobile team is shipping a new standard timestamp format (https://github.com/tinyspeck/slack-objc/pull/88634), so added new regex and mobile parsing logic to support both the new ts and old ts formats

New format: 2024-07-10 T12:46:43.000043 -07:00