### PR TITLE
ci: revert "ci: require `lint-and-test` before queuing builds (#167)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,33 +186,23 @@ workflows:
       - lint-and-test
       - build-macos:
           name: build-macos-x64
-          requires:
-            - lint-and-test
           arch: x64
           filters:
             <<: *job_filter_releases
       - build-macos:
           name: build-macos-arm64
-          requires:
-            - lint-and-test
           arch: arm64
           filters:
             <<: *job_filter_releases
       - build-macos:
           name: build-macos-universal
-          requires:
-            - lint-and-test
           arch: universal
           filters:
             <<: *job_filter_releases
       - build-windows:
-          requires:
-            - lint-and-test
           filters:
             <<: *job_filter_releases
       - build-ubuntu:
-          requires:
-            - lint-and-test
           filters:
             <<: *job_filter_releases
       - code-sign-macos:


### PR DESCRIPTION
This reverts commit ea008d849dd7fad677b7b6a20663466adb9fa421. Fixes the problem of tag publishes not working.