### PR TITLE
fix: escape hatch for invalid zip suggestions

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -136,13 +136,20 @@ export interface MergedFilesLoadStatus {
   mobile: boolean;
 }
 
-export interface Suggestion extends fs.Stats {
+export type Suggestion = ValidSuggestion | InvalidSuggestion;
+
+export interface ValidSuggestion extends fs.Stats {
   age: string;
   filePath: string;
   birthtimeMs: number;
   platform: string;
   appVersion: string;
   instanceUuid: string;
+}
+
+export interface InvalidSuggestion extends fs.Stats {
+  filePath: string;
+  error: Error;
 }
 
 export enum LogLevel {

--- a/src/renderer/components/spotlight.tsx
+++ b/src/renderer/components/spotlight.tsx
@@ -11,6 +11,7 @@ import {
   ProcessedLogFile,
   ProcessedLogFiles,
   UnzippedFile,
+  ValidSuggestion,
 } from '../../interfaces';
 import { isProcessedLogFile } from '../../utils/is-logfile';
 import { highlightText } from '../../utils/highlight-text';
@@ -96,18 +97,18 @@ export class Spotlight extends React.Component<
     const { suggestions } = this.props.state;
     const { processedLogFiles } = this.props.state;
 
-    const spotSuggestions: Array<SpotlightItem> = suggestions.map(
-      ({ filePath, age }) => ({
-        text: path.basename(filePath),
-        label: `${age} old`,
-        icon: filePath.endsWith('zip')
+    const spotSuggestions: Array<SpotlightItem> = suggestions
+      .filter((s) => !('error' in s))
+      .map((s: ValidSuggestion) => ({
+        text: path.basename(s.filePath),
+        label: `${s.age} old`,
+        icon: s.filePath.endsWith('zip')
           ? ('compressed' as const)
           : ('folder-open' as const),
         click: () => {
-          this.props.state.openFile(filePath);
+          this.props.state.openFile(s.filePath);
         },
-      }),
-    );
+      }));
 
     const logFileSuggestions: Array<SpotlightItem> = [];
 

--- a/src/renderer/components/welcome.tsx
+++ b/src/renderer/components/welcome.tsx
@@ -11,6 +11,7 @@ import {
   MobileFilled,
   AndroidFilled,
   SlackCircleFilled,
+  ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import { observer } from 'mobx-react';
 
@@ -18,11 +19,12 @@ import { getSleuth } from '../sleuth';
 import { deleteSuggestion, deleteSuggestions } from '../suggestions';
 import { SleuthState } from '../state/sleuth';
 import { isToday, isThisWeek } from 'date-fns';
-import { Suggestion } from '../../interfaces';
+import { Suggestion, ValidSuggestion } from '../../interfaces';
 
 import fs from 'fs-extra';
 import { getPath } from '../ipc';
 import { FSWatcher } from 'fs';
+import classNames from 'classnames';
 
 export interface WelcomeState {
   sleuth: string;
@@ -78,7 +80,7 @@ export class Welcome extends React.Component<
     await this.props.state.getSuggestions();
   }
 
-  private logFileDescription(item: Suggestion): React.ReactNode {
+  private logFileDescription(item: ValidSuggestion): React.ReactNode {
     let appVersionToUse = item.appVersion;
     if (item.platform === 'android') {
       appVersionToUse = appVersionToUse.split('.', 3).join('.');
@@ -183,7 +185,9 @@ export class Welcome extends React.Component<
 
             return (
               <List.Item
-                className="welcome__suggestion-list-item"
+                className={classNames('welcome__suggestion-list-item', {
+                  'welcome__suggestion-list-item--disabled': 'error' in item,
+                })}
                 actions={[
                   <Button
                     className="welcome__suggestion-delete-btn"
@@ -198,11 +202,19 @@ export class Welcome extends React.Component<
                 ]}
                 onClick={openItem}
               >
-                <List.Item.Meta
-                  avatar={this.platformIcon(item.platform)}
-                  title={<span>{path.basename(item.filePath)}</span>}
-                  description={this.logFileDescription(item)}
-                />
+                {'error' in item ? (
+                  <List.Item.Meta
+                    avatar={<ExclamationCircleOutlined style={iconStyle} />}
+                    title={<span>{path.basename(item.filePath)}</span>}
+                    description={`Failed to parse ZIP! ${item.error.message}`}
+                  />
+                ) : (
+                  <List.Item.Meta
+                    avatar={this.platformIcon(item.platform)}
+                    title={<span>{path.basename(item.filePath)}</span>}
+                    description={this.logFileDescription(item)}
+                  />
+                )}
               </List.Item>
             );
           }}
@@ -240,7 +252,9 @@ export class Welcome extends React.Component<
     return null;
   }
 
-  public renderDeleteStale(staleFiles: Suggestion[]): JSX.Element | null {
+  public renderDeleteStale(
+    staleFiles: Suggestion[],
+  ): JSX.Element | null {
     if (staleFiles.length > 0) {
       const stalePaths = staleFiles.map((f) => f.filePath);
       return (

--- a/src/renderer/components/welcome.tsx
+++ b/src/renderer/components/welcome.tsx
@@ -252,9 +252,7 @@ export class Welcome extends React.Component<
     return null;
   }
 
-  public renderDeleteStale(
-    staleFiles: Suggestion[],
-  ): JSX.Element | null {
+  public renderDeleteStale(staleFiles: Suggestion[]): JSX.Element | null {
     if (staleFiles.length > 0) {
       const stalePaths = staleFiles.map((f) => f.filePath);
       return (

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -79,7 +79,7 @@ export class SleuthState {
   @observable public showOnlySearchResults: boolean | undefined;
 
   // ** Various "what are we showing" properties **
-  @observable public suggestions: Array<Suggestion> = [];
+  @observable public suggestions: Suggestion[] = [];
   @observable public suggestionsLoaded = false;
   @observable public webAppLogsWarningDismissed = false;
   @observable public opened = 0;

--- a/src/renderer/styles/welcome.less
+++ b/src/renderer/styles/welcome.less
@@ -84,11 +84,14 @@
     margin: 0.5rem 0;
   }
 
-  &__suggestion-list-item.ant-list-item {
+  &__suggestion-list-item {
     cursor: pointer;
-    padding: 1rem;
     border-radius: 4px;
     transition: background 0.5s ease-in-out;
+
+    &.ant-list-item {
+      padding: 1rem;
+    }
 
     &:hover {
       background: rgba(200, 200, 200, 0.1);
@@ -96,6 +99,11 @@
       .welcome__suggestion-delete-btn {
         opacity: 100;
       }
+    }
+
+    &--disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
     }
   }
 

--- a/src/renderer/suggestions.ts
+++ b/src/renderer/suggestions.ts
@@ -150,7 +150,6 @@ async function getSuggestionInfo(path: string) {
         }
       });
       zipfile.on('error', (error: Error) => {
-        console.log('rejecting');
         reject(error);
       });
       zipfile.on('end', () => resolve());


### PR DESCRIPTION
If we somehow consume a ZIP file that fails `yauzl` validation, this provides a cleaner UI that removes it from the suggestion list and renders the other files properly.

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/b38829a7-0baf-421d-8db3-d6ab6d7cd92b">
