### PR TITLE
perf: memoize trace warnings

### DIFF
--- a/src/renderer/analytics/trace-analytics.ts
+++ b/src/renderer/analytics/trace-analytics.ts
@@ -1,7 +1,14 @@
 import { UnzippedFile } from '../../interfaces';
 import { readJsonFile } from './read-json-file';
+import { memoize } from 'lodash';
+
+const traceWarnings = memoize(_getTraceWarnings);
 
 export function getTraceWarnings(file: UnzippedFile): Array<string> {
+  return traceWarnings(file);
+}
+
+function _getTraceWarnings(file: UnzippedFile): Array<string> {
   const data = readJsonFile(file);
   const result: Array<string> = [];
 


### PR DESCRIPTION
## Motivation

There's a noticeable performance delay when clicking elements in the sidebar whenever a performance trace ZIP is loaded.

I ran a performance profile and it seems this delay comes from reading the JSON file to get trace warnings.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/f5daa00a-4f13-40c4-9c0d-cb74cdfd4ef9">

## Solution

This PR uses `_.memoize` so that we only do this work once. For each log ZIP, we should actually only have one total value.
