### PR TITLE
style: prevent layout shift when switching between log lines

### DIFF
--- a/src/renderer/styles/details.less
+++ b/src/renderer/styles/details.less
@@ -6,6 +6,7 @@
   overflow: auto;
   flex-grow: 1;
   flex-shrink: 1;
+  scrollbar-gutter: stable;
 
   .ConvertedTable {
     margin: 0.5rem 1.5rem 1rem;


### PR DESCRIPTION
## Problem

This PR addresses a small visual bug that occurs when switching. The example below is from resizing the Details pane, but this also happens when we switch between log lines that have different amount of JSON details.

https://github.com/user-attachments/assets/4425d35f-857d-4fff-bab7-88a2f99b1592

## Solution

The solution for Chromium 94+ is elegant. With `scrollbar-gutter: stable`:

> When using classic scrollbars, the gutter will be present if overflow is auto, scroll, or hidden even if the box is not overflowing. When using overlay scrollbars, the gutter will not be present.

