### PR TITLE
fix(unzip): ensure unique file names

### DIFF
--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -139,8 +139,6 @@ export class CoreApplication extends React.Component<
 
     this.addFilesToState(rawLogFiles);
 
-    console.log(this.state.processedLogFiles?.state);
-
     console.time('process-files');
     for (const type of LOG_TYPES_TO_PROCESS) {
       const preFiles = sortedUnzippedFiles[type];

--- a/test/renderer/unzip.test.ts
+++ b/test/renderer/unzip.test.ts
@@ -31,4 +31,7 @@ describe('Unzipper', () => {
         return unzipper.clean();
       });
   });
+
+  // TODO: this is easy to test but hard to generate a fixture with fake data
+  it.todo('can handle non-unique file names');
 });


### PR DESCRIPTION
ZIP archives can contain multiple files with the same name. There's a longstanding Slack Desktop bug that generates files like these on Windows.

In order to process duplicate files properly, this PR increments non-unique file names with incrementing numbers so that we store them with unique file names on disk.