### PR TITLE
fix: wrap excessively long log line descriptions

### DIFF
--- a/src/renderer/styles/details.less
+++ b/src/renderer/styles/details.less
@@ -80,6 +80,7 @@
     margin-bottom: 0.625rem;
     margin-top: 10px;
     padding: 12px 25px 12px 12px;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
Tiny PR that fixes excessively long log lines not rendering properly.
