### PR TITLE
chore: remove `baseUrl` from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "pretty": true,
     "target": "es2019",
     "jsx": "react",
-    "typeRoots": ["./node_modules/@types"],
-    "baseUrl": "."
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src/**/*", "./jest-setup.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This fixes the problem where auto-imports would default to `src/main/my-file.ts` instead of using relative imports.

