### PR TITLE
fix: wire omnibar keyboard shortcut

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -79,6 +79,8 @@ export const SleuthAPI = {
     }),
   setupToggleSidebar: (cb: () => void) =>
     ipcRenderer.on(IpcEvents.TOGGLE_SIDEBAR, cb),
+  setupToggleSpotlight: (cb: () => void) =>
+    ipcRenderer.on(IpcEvents.TOGGLE_SPOTLIGHT, cb),
   setColorTheme: (colorTheme: ColorTheme) =>
     ipcRenderer.invoke(IpcEvents.SET_COLOR_THEME, colorTheme),
   /**

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -219,6 +219,7 @@ export class SleuthState {
 
     setupTouchBarAutoruns(this);
     window.Sleuth.setupToggleSidebar(this.toggleSidebar);
+    window.Sleuth.setupToggleSpotlight(this.toggleSpotlight);
     window.Sleuth.setupOpenBookmarks((_event, data) =>
       importBookmarks(this, data),
     );


### PR DESCRIPTION
Forgot to add this to the preload in https://github.com/tinyspeck/sleuth/pull/207