### PR TITLE
feat: parse webapp JSON log lines

### DIFF
--- a/src/main/filesystem/read-file.ts
+++ b/src/main/filesystem/read-file.ts
@@ -350,11 +350,21 @@ export function matchLineWebApp(line: string): MatchResult | undefined {
       message = message.slice(WEBAPP_NEW_TIMESTAMP_RGX.lastIndex);
     }
 
+    let meta: string | undefined = undefined;
+
+    // As a shortcut, detect `{` as the start of some JSON and store it into the meta
+    const indexOfJSON = message.indexOf('{');
+    if (indexOfJSON > -1) {
+      meta = message.slice(indexOfJSON);
+      message = message.slice(0, indexOfJSON);
+    }
+
     return {
       timestamp: results[1],
       level: results[2].toLowerCase(),
       message,
       momentValue,
+      meta,
     };
   }
 

--- a/test/main/read-file.test.ts
+++ b/test/main/read-file.test.ts
@@ -72,7 +72,15 @@ describe('readFile', () => {
     };
 
     return readLogFile(file, LogType.WEBAPP).then(({ entries }) => {
-      expect(entries).toHaveLength(3);
+      expect(entries).toHaveLength(4);
+      // Can parse JSON meta
+      expect(JSON.parse(entries[3].meta as string)).toEqual({
+        viewSet: {
+          sidebar: { id: 'ChannelList', viewType: 'ChannelList' },
+          primary: { id: 'Punreads', viewType: 'Page' },
+        },
+        nextTab: 'home',
+      });
     });
   });
 });

--- a/test/static/webapp.log
+++ b/test/static/webapp.log
@@ -1,3 +1,4 @@
 [10/28/19, 14:52:34:884] info: Oct-28 14:52:34.884 [API-Q] (T024BE7LD) noversion-1572299554.883 Flannel users/info is ACTIVE
 [10/28/19, 14:52:34:917] info: Oct-28 14:52:34.917 [API-Q] (T024BE7LD) noversion-1572299554.883 Flannel users/info is RESOLVED
 [10/28/19, 14:52:35:210] info: Oct-28 14:52:35.210 [COUNTS] (T024BE7LD) Updated unread_cnt for CA91ZPRDW: 2
+[06/03/25, 23:15:14:181] info: [NAVIGATE-IN-MAIN-WIND] Built view set after middleware {"viewSet":{"sidebar":{"id":"ChannelList","viewType":"ChannelList"},"primary":{"id":"Punreads","viewType":"Page"}},"nextTab":"home"} 


### PR DESCRIPTION
Quick and dirty hack to parse webapp log line JSON payloads into the log line details.

```
[06/03/25, 23:15:14:181] info: [NAVIGATE-IN-MAIN-WIND] Built view set after middleware {"viewSet":{"sidebar":{"id":"ChannelList","viewType":"ChannelList"},"primary":{"id":"Punreads","viewType":"Page"}},"nextTab":"home"}
```