### PR TITLE
fix: more usable log line detail

### DIFF
--- a/src/renderer/components/log-line-details/details.tsx
+++ b/src/renderer/components/log-line-details/details.tsx
@@ -58,7 +58,6 @@ export const LogLineDetails = observer((props: LogLineDetailsProps) => {
           height: '100%',
           borderRadius: 0,
         }}
-        title={<span title={message}>{message}</span>}
         extra={
           <div className="Details-LogType">
             <Space>
@@ -114,6 +113,7 @@ export const LogLineDetails = observer((props: LogLineDetailsProps) => {
           </div>
         }
       >
+        <div className="LogLine Monospace">{message}</div>
         {selectedEntry?.meta && !selectedRangeEntries && (
           <Card>
             <LogLineData state={props.state} meta={selectedEntry.meta} />

--- a/src/renderer/components/log-line-details/details.tsx
+++ b/src/renderer/components/log-line-details/details.tsx
@@ -65,7 +65,12 @@ export const LogLineDetails = observer((props: LogLineDetailsProps) => {
                 <Button
                   size="small"
                   onClick={() => {
-                    if (selectedEntry) {
+                    if (selectedRangeEntries) {
+                      const copyText = selectedRangeEntries
+                        .map(getCopyText)
+                        .join('\n');
+                      window.Sleuth.clipboard.writeText(copyText);
+                    } else if (selectedEntry) {
                       const copyText = getCopyText(selectedEntry);
                       window.Sleuth.clipboard.writeText(copyText);
                     }

--- a/src/renderer/styles/details.less
+++ b/src/renderer/styles/details.less
@@ -14,10 +14,6 @@
     margin: 0.5rem 1.5rem 1rem;
   }
 
-  .ant-card-head-title {
-    font-size: var(--ant-font-size);
-  }
-
   .ant-card-body {
     height: calc(
       100% - var(--ant-card-header-height) - 24px - 2 *
@@ -47,4 +43,13 @@
   width: 100%;
   border-bottom: 1px solid var(--ant-color-border);
   border-top: 1px solid var(--ant-color-border);
+}
+
+.LogLine {
+  background: var(--ant-color-bg-layout);
+  font-family: 'Inconsolata', monospace;
+  padding: 12px;
+  margin-bottom: 12px;
+  border-radius: var(--ant-border-radius-lg);
+  font-weight: bold;
 }


### PR DESCRIPTION
Reverts the details UX closer to what it used to be pre-antd :)

<img width="793" height="451" alt="image" src="https://github.com/user-attachments/assets/f2583990-43c5-45cf-a60b-df91cf44a7f4" />

