### PR TITLE
style: enhance log table UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,10 @@
     <title>Sleuth</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' 'nonce-3589333976'; font-src 'self' https://fonts.gstatic.com; worker-src blob:"
+      content="script-src 'self' 'nonce-3589333976'; font-src 'self'; worker-src blob:"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="./src/renderer/styles/styles.css" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Inconsolata"
-    />
   </head>
   <body>
     <div id="SlackApp"></div>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
     "@date-fns/tz": "^1.4.1",
+    "@fontsource/fira-code": "^5.2.7",
     "antd": "^5.25.3",
     "chart.js": "3.5.0",
     "chartjs-adapter-date-fns": "^2.0.0",

--- a/src/main/filesystem/read-file.ts
+++ b/src/main/filesystem/read-file.ts
@@ -17,6 +17,8 @@ import { TZDate } from '@date-fns/tz';
 
 const d = debug('sleuth:read-file');
 
+const MAX_TO_PARSE = 100_000; // 100 KB cap on multi-line meta accumulation
+
 const DESKTOP_RGX = /^\s*\[([\d/,\s:]{22,24})\] ([A-Za-z]{0,20}):?(.*)$/g;
 
 const WEBAPP_A_RGX = /^(\w*): (.{3}-\d{1,2} \d{2}:\d{2}:\d{2}.\d{0,3}) (.*)$/;
@@ -383,22 +385,31 @@ export function readLogFile(
             logFile.fileName.startsWith('console-export-'))
         ) {
           // For console logs which are typed as webapp so we can't just detect using type:
-          if (toParse && toParse.length > 0) {
+          if (toParse && toParse.length > 0 && toParse.length < MAX_TO_PARSE) {
             // If there's already a meta, just add to the meta
             toParse += line + '\n';
           } else if (
-            line.includes('@') ||
-            line.includes('(async)') ||
-            line.match(/Show [\d]+ more frames/)
+            toParse.length < MAX_TO_PARSE &&
+            (line.includes('@') ||
+              line.includes('(async)') ||
+              line.match(/Show [\d]+ more frames/))
           ) {
             // This is part of a stack trace - I could add it to the above line but that's a mouthful
             toParse += line + '\n';
           } else {
             current.message += '\n' + line;
           }
-        } else {
+        } else if (toParse.length < MAX_TO_PARSE) {
           // This is (hopefully) part of a meta object
           toParse += line + '\n';
+        } else if (!toParse.endsWith('[truncated]\n')) {
+          d(
+            'Meta accumulation exceeded %d bytes for entry at line %d in %s, truncating',
+            MAX_TO_PARSE,
+            current?.line,
+            logFile.fileName,
+          );
+          toParse += '[truncated]\n';
         }
       }
     }
@@ -453,12 +464,26 @@ export function matchLineWebApp(
     }
 
     let meta: string | undefined = undefined;
+    let toParseHead: string | undefined = undefined;
 
     // As a shortcut, detect `{` as the start of some JSON and store it into the meta
     const indexOfJSON = message.indexOf('{');
     if (indexOfJSON > -1) {
-      meta = message.slice(indexOfJSON);
+      const jsonPart = message.slice(indexOfJSON);
       message = message.slice(0, indexOfJSON);
+      // If the JSON braces are balanced on this line, store as meta directly.
+      // Otherwise, seed the multi-line accumulator so subsequent lines
+      // are concatenated into a complete object.
+      let depth = 0;
+      for (let i = 0; i < jsonPart.length; i++) {
+        if (jsonPart[i] === '{') depth++;
+        else if (jsonPart[i] === '}') depth--;
+      }
+      if (depth <= 0) {
+        meta = jsonPart;
+      } else {
+        toParseHead = jsonPart + '\n';
+      }
     }
 
     return {
@@ -467,6 +492,7 @@ export function matchLineWebApp(
       message,
       momentValue,
       meta,
+      toParseHead,
     };
   }
 
@@ -1007,11 +1033,12 @@ export function makeLogEntry(
   line: number,
   sourceFile: string,
 ): LogEntry {
-  options.message = options.message || '';
-  options.timestamp = options.timestamp || '';
-  options.level = options.level || '';
+  const { toParseHead: _, ...rest } = options;
+  rest.message = rest.message || '';
+  rest.timestamp = rest.timestamp || '';
+  rest.level = rest.level || '';
 
-  const logEntry = { ...options, logType, line, sourceFile };
+  const logEntry = { ...rest, logType, line, sourceFile };
   return logEntry as LogEntry;
 }
 

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -38,12 +38,87 @@ import { between } from '../../utils/is-between';
 import { getRangeEntries } from '../../utils/get-range-from-array';
 import { RepeatedLevels } from '../../shared-constants';
 import { reaction, runInAction, toJS } from 'mobx';
-import { Tag } from 'antd';
+import { Tag, Tooltip } from 'antd';
 import { observer } from 'mobx-react';
 import { getCopyText } from '../state/copy';
-import { PaperClipOutlined, PartitionOutlined } from '@ant-design/icons';
+import { PartitionOutlined } from '@ant-design/icons';
 
 const d = debug('sleuth:logtable');
+
+/**
+ * Something like `[HUDDLES]` in webapp logs
+ */
+const WEBAPP_TAG_RGX = /^\s*\[([A-Za-z][A-Za-z0-9_ -]+)\]/;
+/**
+ * Something like `Store:` in desktop logs
+ */
+const BROWSER_PREFIX_RGX = /^\s*([A-Za-z][A-Za-z0-9_-]*(?:\s*\[[^\]]+\])?):/;
+/**
+ * Something like `Tag = fooBarEpic;` for rxjs-spy debug logs
+ */
+const BROWSER_EPIC_TAG_PREFIX = /^\s*Tag = ([A-Za-z][A-Za-z0-9_]*);/;
+
+const tagColorCache = new Map<string, string>();
+
+/**
+ * Maps a string to a hex code
+ */
+function hashTagColor(tag: string, dark: boolean): string {
+  const key = `${dark ? 'd' : 'l'}:${tag}`;
+  const cached = tagColorCache.get(key);
+  if (cached) return cached;
+
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++) {
+    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = ((hash % 360) + 360) % 360;
+  // Yellow-green (40–160) needs lower lightness for contrast on white backgrounds
+  // Blue-purple (220–310) needs higher lightness for contrast on dark backgrounds
+  const l = dark
+    ? h >= 220 && h < 310
+      ? 78
+      : 65
+    : h >= 40 && h < 160
+      ? 32
+      : 45;
+  const s = dark && h >= 220 && h < 310 ? 95 : 80;
+  const color = `hsl(${h}, ${s}%, ${l}%)`;
+  tagColorCache.set(key, color);
+  return color;
+}
+
+function matchTag(msg: string): RegExpExecArray | null {
+  return (
+    WEBAPP_TAG_RGX.exec(msg) ||
+    BROWSER_PREFIX_RGX.exec(msg) ||
+    BROWSER_EPIC_TAG_PREFIX.exec(msg)
+  );
+}
+
+const MSG_ICON_STYLE = {
+  flexShrink: 0,
+  width: '1.25em',
+  textAlign: 'center' as const,
+};
+const MSG_TEXT_STYLE = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap' as const,
+  minWidth: 0,
+};
+const MSG_ROW_STYLE = {
+  display: 'flex',
+  gap: '0.25rem',
+  overflow: 'hidden',
+  minWidth: 0,
+  alignItems: 'center' as const,
+};
+const PROCESS_TAG_STYLE = {
+  fontFamily: "'Fira Code', monospace",
+  width: 80,
+  textAlign: 'center' as const,
+};
 
 export const logColorMap: Record<ProcessableLogType, string> = {
   [LogType.BROWSER]: 'cyan',
@@ -453,24 +528,35 @@ export const LogTable = observer((props: LogTableProps) => {
    */
   const renderMessageCell = useCallback(
     ({ rowData: entry }: TableCellProps): JSX.Element | string => {
-      const message = entry.highlightMessage ?? entry.message;
+      const display = entry.highlightMessage ?? entry.message;
 
-      if (entry && entry.meta) {
-        const icon = isReduxAction(entry.message) ? (
-          <PartitionOutlined />
-        ) : (
-          <PaperClipOutlined />
-        );
-        return (
-          <div style={{ display: 'flex', gap: '0.25rem' }}>
-            <span title={entry.message}>{icon}</span>
-            <span title={entry.message}>{message}</span>
-          </div>
-        );
-      } else if (entry && entry.repeated) {
+      // Always extract tag from the raw message so it works with highlight elements too
+      const tagMatch = matchTag(entry.message);
+      const tag = tagMatch ? tagMatch[1] : null;
+      const tagDisplay = tagMatch ? tagMatch[0].trim() : null;
+      const msgAfterTag = tagMatch
+        ? typeof display === 'string'
+          ? display.slice(tagMatch[0].length)
+          : display
+        : display;
+
+      const tagSpan = tag ? (
+        <span
+          style={{
+            color: hashTagColor(tag, state.prefersDarkColors),
+            flexShrink: 0,
+          }}
+        >
+          {tagDisplay}
+        </span>
+      ) : null;
+
+      // Determine icon: repeated-entry emoji or meta attachment icon
+      let icon: JSX.Element | null = null;
+      let iconTitle: string | undefined;
+      if (entry?.repeated) {
         const count = entry.repeated.length;
         let emoji = '';
-
         if (count > RepeatedLevels.NOTIFY) {
           emoji = '🛑';
         } else if (count > RepeatedLevels.WARNING) {
@@ -478,19 +564,37 @@ export const LogTable = observer((props: LogTableProps) => {
         } else if (count > RepeatedLevels.ERROR) {
           emoji = '🔥';
         }
-
-        const emojiMessage = `(${emoji} Repeated ${entry.repeated.length} times)`;
-        return (
-          <div style={{ display: 'flex', gap: '0.25rem' }}>
-            <span>{emojiMessage}</span>
-            <span>{message}</span>
-          </div>
+        icon = (
+          <Tooltip title={`Repeated ${count} times`}>
+            <span>{emoji || '🔁'}</span>
+          </Tooltip>
         );
-      } else {
-        return message;
+      } else if (entry?.meta) {
+        iconTitle = entry.message;
+        icon = isReduxAction(entry.message) ? (
+          <Tooltip title="Redux action">
+            <PartitionOutlined />
+          </Tooltip>
+        ) : (
+          <Tooltip title="Contains JSON metadata">
+            <span>{'{}'}</span>
+          </Tooltip>
+        );
       }
+
+      return (
+        <div style={MSG_ROW_STYLE}>
+          <span style={MSG_ICON_STYLE} title={iconTitle}>
+            {icon}
+          </span>
+          {tagSpan}
+          <span style={MSG_TEXT_STYLE} title={entry?.message}>
+            {msgAfterTag}
+          </span>
+        </div>
+      );
     },
-    [],
+    [state.prefersDarkColors],
   );
 
   /**
@@ -640,27 +744,27 @@ export const LogTable = observer((props: LogTableProps) => {
         <Column
           label="Index"
           dataKey="index"
-          width={100}
+          width={75}
           flexGrow={0}
           flexShrink={1}
         />
-        <Column label="Line" dataKey="line" width={100} />
         <Column
           label="Timestamp"
           cellRenderer={renderTimestampCell}
           dataKey="momentValue"
           width={200}
-          flexGrow={2}
+          flexGrow={0}
         />
-        <Column label="Level" dataKey="level" width={100} />
+        <Column label="Level" dataKey="level" width={80} />
         {logFile.logType === LogType.ALL ? (
           <Column
             label="Process"
             dataKey="logType"
-            width={120}
+            width={100}
             cellRenderer={({ cellData }: TableCellProps) => (
               <Tag
                 color={logColorMap[cellData as ProcessableLogType] ?? 'default'}
+                style={PROCESS_TAG_STYLE}
               >
                 {cellData}
               </Tag>

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,3 +1,5 @@
+import '@fontsource/fira-code/400.css';
+import '@fontsource/fira-code/500.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './components/app';

--- a/src/renderer/styles/details.css
+++ b/src/renderer/styles/details.css
@@ -47,9 +47,9 @@
 
 .LogLine {
   background: var(--ant-color-bg-layout);
-  font-family: 'Inconsolata', monospace;
+  font-family: 'Fira Code', monospace;
   padding: 12px;
   margin-bottom: 12px;
   border-radius: var(--ant-border-radius-lg);
-  font-weight: bold;
+  font-weight: normal;
 }

--- a/src/renderer/styles/log-table.css
+++ b/src/renderer/styles/log-table.css
@@ -11,6 +11,8 @@
   flex-grow: 1;
   padding-top: 1rem;
   user-select: none;
+  font-family: 'Fira Code', monospace;
+  font-size: 13px;
 
   &.Single {
     .Meta {
@@ -36,52 +38,88 @@
     border-bottom: 1px solid rgba(16, 22, 26, 0.05);
   }
 
-  .ReactVirtualized__Table__row:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+  .ReactVirtualized__Table__rowColumn {
+    overflow: hidden !important;
   }
 
-  .HighlightRow {
+  .ReactVirtualized__Table__row:hover {
     background-color: rgba(0, 0, 0, 0.1);
   }
 
+  .HighlightRow {
+    background-color: rgba(0, 0, 0, 0.15);
+  }
+
   .ActiveRow {
-    font-weight: 700;
-    background-color: rgba(0, 0, 0, 0.3);
+    font-weight: 500;
+    background-color: rgba(0, 0, 0, 0.15);
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.15);
+    }
   }
 
   .ErrorRow {
-    background-color: rgba(255, 0, 0, 0.2);
+    background-color: rgba(255, 0, 0, 0.25);
 
     &.HighlightRow,
-    &.ActiveRow {
-      background-color: rgba(255, 0, 0, 0.3);
+    &.ActiveRow,
+    &.ActiveRow:hover {
+      background-color: rgba(255, 0, 0, 0.35);
     }
   }
 
   .WarnRow {
-    background-color: rgba(255, 200, 0, 0.1);
+    background-color: rgba(255, 200, 0, 0.15);
 
     &.HighlightRow,
-    &.ActiveRow {
-      background-color: rgba(255, 200, 0, 0.2);
+    &.ActiveRow,
+    &.ActiveRow:hover {
+      background-color: rgba(255, 200, 0, 0.25);
     }
   }
-}
 
-@media (prefers-color-scheme: dark) {
-  .ReactVirtualized__Table__row {
-    border-bottom: 1px solid rgba(137, 191, 226, 0.05);
-  }
+  @media (prefers-color-scheme: dark) {
+    .ReactVirtualized__Table__row {
+      border-bottom: 1px solid rgba(137, 191, 226, 0.08);
+    }
 
-  .ReactVirtualized__Table__row:hover {
-    background-color: rgba(255, 255, 255, 0.05);
-  }
+    .ReactVirtualized__Table__row:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+    }
 
-  .HighlightRow {
-    background-color: rgba(255, 255, 255, 0.1);
-  }
+    .HighlightRow {
+      background-color: rgba(255, 255, 255, 0.08);
+    }
 
-  .ActiveRow {
-    background-color: rgba(255, 255, 255, 0.2);
+    .ActiveRow {
+      background-color: rgba(255, 255, 255, 0.15);
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.15);
+      }
+    }
+
+    .ErrorRow {
+      color: rgb(255, 120, 120);
+      background-color: rgba(255, 0, 0, 0.2);
+
+      &.HighlightRow,
+      &.ActiveRow,
+      &.ActiveRow:hover {
+        background-color: rgba(255, 0, 0, 0.45);
+      }
+    }
+
+    .WarnRow {
+      color: rgb(255, 210, 80);
+      background-color: rgba(255, 200, 0, 0.12);
+
+      &.HighlightRow,
+      &.ActiveRow,
+      &.ActiveRow:hover {
+        background-color: rgba(255, 200, 0, 0.35);
+      }
+    }
   }
 }

--- a/src/renderer/styles/root.css
+++ b/src/renderer/styles/root.css
@@ -7,7 +7,7 @@ body {
 }
 
 .Monospace {
-  font-family: 'Inconsolata', monospace;
+  font-family: 'Fira Code', monospace;
   white-space: pre-wrap;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fontsource/fira-code@npm:^5.2.7":
+  version: 5.2.7
+  resolution: "@fontsource/fira-code@npm:5.2.7"
+  checksum: 10c0/389d1356def9018da529bf6055af9d41d6f6ae9ee2ff804a9b0e3bd2f8cf2754967e2b4a25e267d21215278849fb13711b9fe9573c051a1e191ad737e55f125f
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -8550,6 +8557,7 @@ __metadata:
     "@electron-forge/plugin-auto-unpack-natives": "npm:8.0.0-alpha.6"
     "@electron-forge/plugin-vite": "patch:@electron-forge/plugin-vite@npm%3A8.0.0-alpha.6#~/.yarn/patches/@electron-forge-plugin-vite-npm-8.0.0-alpha.6-eae1e3d3c3.patch"
     "@electron-forge/publisher-github": "npm:8.0.0-alpha.6"
+    "@fontsource/fira-code": "npm:^5.2.7"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^12.1.2"
     "@types/classnames": "npm:^2.2.11"


### PR DESCRIPTION
This is best viewed in the "All Desktop Logs" view. This PR contains a bunch of styling changes that aim to make the log view more readable.

* **Font change:** the log table is now [Fira Code](https://github.com/tonsky/FiraCode). I think monospace fonts are useful for visual distinction.
* **Prefix highlighting:** the log table now checks each log line for a prefix and dynamically generates a colour code for it based on the text content. _Note that this is naively done while rendering the `log-table.tsx` component. We could probably move this to the log processing pipeline if this degrades performance, but since we're working with a virtualized table, we're not running 10000s of regex matches as is._
* **No more "Line" column:** exact line in a specific browser log file isn't very useful and takes up space.
* **Icon updates:** the icons that come with each line have been modified slightly and now come with tooltips.

<img width="1840" height="1102" alt="image" src="https://github.com/user-attachments/assets/e6b4c742-d879-4b06-b877-8e0103230701" />
