### PR TITLE
feat: full sidebar revamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ The app follows standard Electron patterns with three main processes:
 
 #### Key Interfaces
 
-- **LogEntry** (`src/interfaces.ts`): Core data structure for log entries
+- **LogEntry** (`src/interfaces.ts`): Core data structure with optional `tag: { name, offset }` for pre-parsed tag metadata
 - **UnzippedFile/ProcessedLogFile/MergedLogFile**: File handling abstractions
 - **LogType** enum: Defines supported log file types
 
@@ -83,7 +83,7 @@ The core flow for processing log bundles:
 3. **Type categorization** (`src/utils/get-file-types.ts`): `getTypesForFiles()` classifies each file by filename pattern into `LogType` (BROWSER, WEBAPP, NETLOG, INSTALLER, MOBILE, CHROMIUM, STATE, TRACE, UNKNOWN).
 4. **Routing** (`app-core.tsx`): Files split into raw files (STATE, NETLOG, TRACE — displayed as-is) and processable files (BROWSER, WEBAPP, INSTALLER, MOBILE, CHROMIUM — parsed line-by-line).
 5. **State files read first**: `log-context.json` provides timezone info used during log parsing.
-6. **Line-by-line parsing** (`src/main/filesystem/read-file.ts`): `readLogFile()` streams each file, applying type-specific regex matchers (e.g., `matchLineElectron`, `matchLineWebApp`). Each matched line becomes a `LogEntry` with timestamp, level, message, and metadata. Repeated consecutive lines are collapsed.
+6. **Line-by-line parsing** (`src/main/filesystem/read-file.ts`): `readLogFile()` streams each file, applying type-specific regex matchers (e.g., `matchLineElectron`, `matchLineWebApp`). Each matched line becomes a `LogEntry` with timestamp, level, message, and metadata. Tags extracted via `matchTag()` (`src/utils/match-tag.ts`). Repeated consecutive lines are collapsed.
 7. **Merging & sorting** (`src/renderer/processor.ts`): `mergeLogFiles()` combines entries from multiple files of the same type using a synchronous k-way merge (sorted chronologically). Produces merged views for Browser, Webapp, and combined ALL.
 8. **Display**: Results stored in MobX `SleuthState`, populating Sidebar (file tree), LogTable (virtualized entries), and detail panels.
 
@@ -96,6 +96,7 @@ Key file dispatch: `src/main/filesystem/open-file.ts` routes between `openZip()`
 - **NetLog Viewing**: Network log analysis
 - **Bookmarking**: Save and restore specific log entries
 - **Log Merging**: Combine multiple log files chronologically
+- **Tag Extraction**: Pre-parsed tag metadata via `src/utils/match-tag.ts`, used for sidebar filtering and log table coloring
 
 ## Testing
 
@@ -120,9 +121,17 @@ Key file dispatch: `src/main/filesystem/open-file.ts` routes between `openZip()`
 
 - `src/main/`: Main process Electron code
 - `src/renderer/`: React renderer code
+- `src/renderer/styles/`: CSS files using antd CSS variable tokens
 - `src/preload/`: Preload script for secure IPC
-- `src/utils/`: Shared utilities (renderer-safe only)
+- `src/utils/`: Shared utilities (importable by both main and renderer processes)
 - `src/interfaces.ts`: Shared TypeScript interfaces
+
+### Styling Conventions
+
+- Prefer CSS classes in `src/renderer/styles/*.css` over inline styles
+- Use antd CSS variable tokens (`--ant-padding-*`, `--ant-font-size-*`, `--ant-color-*`, `--ant-border-radius-*`, `--ant-line-width`) for spacing/sizing
+- Font size tokens: `--ant-font-size-sm` (12px), `--ant-font-size` (14px), `--ant-font-size-lg` (16px), `--ant-font-size-xl` (20px) — no XS token
+- Runtime-dependent values (computed colors, hover opacity) stay as inline `style`
 
 ### State Patterns
 
@@ -130,6 +139,11 @@ Key file dispatch: `src/main/filesystem/open-file.ts` routes between `openZip()`
 - State mutations only through actions
 - Computed values for derived data
 - Autorun for side effects
+
+### Filter Semantics
+
+- **LevelFilter / LogTypeFilter**: `Record<key, boolean>` — `true` = visible, all `true` = no filtering, all `false` = show nothing
+- **Tag filter** (`selectedTags: string[]`): empty = show all, non-empty = show only matching tags
 
 ## Development Notes
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,9 +10,9 @@ export type RepeatedCounts = Record<string, number>;
 export enum LogType {
   ALL = 'all',
   BROWSER = 'browser',
-  EPIC_TRACES = 'epic_traces',
+  rx_epic = 'rx_epic',
   WEBAPP = 'webapp',
-  SERVICE_WORKER = 'service_worker',
+  SERVICE_WORKER = 'webapp_sw',
   STATE = 'state',
   NETLOG = 'netlog',
   TRACE = 'trace',
@@ -27,7 +27,7 @@ export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 
 export const LOG_TYPES_TO_PROCESS = [
   LogType.BROWSER,
-  LogType.EPIC_TRACES,
+  LogType.rx_epic,
   LogType.WEBAPP,
   LogType.SERVICE_WORKER,
   LogType.INSTALLER,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -82,6 +82,16 @@ export interface LogEntry {
   index: number;
   timestamp: string;
   message: string;
+  tag?: {
+    /** The extracted tag name, e.g. `"Store"`, `"HUDDLES"`, `"fooBarEpic"`.
+     *  Used for color hashing and display grouping. */
+    name: string;
+    /** Length of the full prefix match in the original message string,
+     *  e.g. `"Store:"` is 6, `"[HUDDLES]"` is 9, `"Tag = fooBarEpic;"` is 18.
+     *  Lets the renderer slice the display prefix and remaining message
+     *  without re-running the regex. */
+    offset: number;
+  };
   level: LogLevel;
   logType: LogType;
   line: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,7 @@ export type RepeatedCounts = Record<string, number>;
 export enum LogType {
   ALL = 'all',
   BROWSER = 'browser',
-  rx_epic = 'rx_epic',
+  RX_EPIC = 'rx_epic',
   WEBAPP = 'webapp',
   SERVICE_WORKER = 'webapp_sw',
   STATE = 'state',
@@ -27,7 +27,7 @@ export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 
 export const LOG_TYPES_TO_PROCESS = [
   LogType.BROWSER,
-  LogType.rx_epic,
+  LogType.RX_EPIC,
   LogType.WEBAPP,
   LogType.SERVICE_WORKER,
   LogType.INSTALLER,
@@ -78,20 +78,22 @@ export interface DateRange {
   to: Date | null;
 }
 
+export interface LogTag {
+  /** The extracted tag name, e.g. `"Store"`, `"HUDDLES"`, `"fooBarEpic"`.
+   *  Used for color hashing and display grouping. */
+  name: string;
+  /** Length of the full prefix match in the original message string,
+   *  e.g. `"Store:"` is 6, `"[HUDDLES]"` is 9, `"Tag = fooBarEpic;"` is 18.
+   *  Lets the renderer slice the display prefix and remaining message
+   *  without re-running the regex. */
+  offset: number;
+}
+
 export interface LogEntry {
   index: number;
   timestamp: string;
   message: string;
-  tag?: {
-    /** The extracted tag name, e.g. `"Store"`, `"HUDDLES"`, `"fooBarEpic"`.
-     *  Used for color hashing and display grouping. */
-    name: string;
-    /** Length of the full prefix match in the original message string,
-     *  e.g. `"Store:"` is 6, `"[HUDDLES]"` is 9, `"Tag = fooBarEpic;"` is 18.
-     *  Lets the renderer slice the display prefix and remaining message
-     *  without re-running the regex. */
-    offset: number;
-  };
+  tag?: LogTag;
   level: LogLevel;
   logType: LogType;
   line: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,9 @@ export type RepeatedCounts = Record<string, number>;
 export enum LogType {
   ALL = 'all',
   BROWSER = 'browser',
+  EPIC_TRACES = 'epic_traces',
   WEBAPP = 'webapp',
+  SERVICE_WORKER = 'service_worker',
   STATE = 'state',
   NETLOG = 'netlog',
   TRACE = 'trace',
@@ -25,7 +27,9 @@ export type SelectableLogType = Exclude<LogType, LogType.UNKNOWN>;
 
 export const LOG_TYPES_TO_PROCESS = [
   LogType.BROWSER,
+  LogType.EPIC_TRACES,
   LogType.WEBAPP,
+  LogType.SERVICE_WORKER,
   LogType.INSTALLER,
   LogType.MOBILE,
   LogType.CHROMIUM,
@@ -154,6 +158,7 @@ export enum LogLevel {
 }
 
 export type LevelFilter = Record<LogLevel, boolean>;
+export type LogTypeFilter = Record<ProcessableLogType, boolean>;
 export type LogMetrics = Record<LogLevel, number>;
 export type TimeBucketedLogMetrics = Record<number, LogMetrics>;
 

--- a/src/main/filesystem/read-file.ts
+++ b/src/main/filesystem/read-file.ts
@@ -11,6 +11,7 @@ import {
   UnzippedFile,
 } from '../../interfaces';
 import { getTypeForFile } from '../../utils/get-file-types';
+import { matchTag } from '../../utils/match-tag';
 import debug from 'debug';
 import { StateTableState } from '../../renderer/components/state-table';
 import { TZDate } from '@date-fns/tz';
@@ -1040,8 +1041,14 @@ export function makeLogEntry(
   rest.timestamp = rest.timestamp || '';
   rest.level = rest.level || '';
 
-  const logEntry = { ...rest, logType, line, sourceFile };
-  return logEntry as LogEntry;
+  const logEntry = { ...rest, logType, line, sourceFile } as LogEntry;
+
+  const tagMatch = matchTag(logEntry.message);
+  if (tagMatch) {
+    logEntry.tag = { name: tagMatch[1], offset: tagMatch[0].length };
+  }
+
+  return logEntry;
 }
 
 export interface ReadFileResult {

--- a/src/main/filesystem/read-file.ts
+++ b/src/main/filesystem/read-file.ts
@@ -967,7 +967,9 @@ export function getMatchFunction(
   logType: LogType,
   logFile: UnzippedFile,
 ): (line: string, userTZ?: string) => MatchResult | undefined {
-  if (logType === LogType.WEBAPP) {
+  if (logType === LogType.SERVICE_WORKER) {
+    return matchLineWebApp;
+  } else if (logType === LogType.WEBAPP) {
     if (
       logFile.fileName.startsWith('app.slack') ||
       logFile.fileName.startsWith('console')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -236,7 +236,7 @@ export class IpcManager {
       return new Promise((resolve) => {
         const maybeShowInContext: MenuItemConstructorOptions[] =
           type === LogType.BROWSER ||
-          type === LogType.EPIC_TRACES ||
+          type === LogType.rx_epic ||
           type === LogType.WEBAPP ||
           type === LogType.SERVICE_WORKER
             ? [

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -235,7 +235,10 @@ export class IpcManager {
     ipcMain.handle(IpcEvents.OPEN_LOG_CONTEXT_MENU, (event, type: LogType) => {
       return new Promise((resolve) => {
         const maybeShowInContext: MenuItemConstructorOptions[] =
-          type === LogType.BROWSER || type === LogType.WEBAPP
+          type === LogType.BROWSER ||
+          type === LogType.EPIC_TRACES ||
+          type === LogType.WEBAPP ||
+          type === LogType.SERVICE_WORKER
             ? [
                 {
                   type: 'separator',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -236,7 +236,7 @@ export class IpcManager {
       return new Promise((resolve) => {
         const maybeShowInContext: MenuItemConstructorOptions[] =
           type === LogType.BROWSER ||
-          type === LogType.rx_epic ||
+          type === LogType.RX_EPIC ||
           type === LogType.WEBAPP ||
           type === LogType.SERVICE_WORKER
             ? [

--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   DatePicker,
   Divider,
-  Dropdown,
   Input,
   InputRef,
   Space,
@@ -16,15 +15,9 @@ import { SleuthState } from '../state/sleuth';
 import {
   ArrowDownOutlined,
   ArrowUpOutlined,
-  BugOutlined,
   EyeInvisibleOutlined,
   EyeOutlined,
-  FilterOutlined,
-  FilterTwoTone,
-  FireOutlined,
-  InfoCircleOutlined,
   SearchOutlined,
-  WarningOutlined,
 } from '@ant-design/icons';
 import { TZDate, tzOffset } from '@date-fns/tz';
 import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
@@ -37,7 +30,6 @@ export interface FilterProps {
 
 export const Filter = observer((props: FilterProps) => {
   const searchRef = React.useRef<InputRef>(null);
-  const [open, setOpen] = React.useState(false);
 
   /**
    * Handles an increment or decrement of the selected index in the
@@ -124,106 +116,6 @@ export const Filter = observer((props: FilterProps) => {
     dateFnsGenerateConfig,
   );
 
-  function renderFilter() {
-    const { error, warn, info, debug } = props.state.levelFilter;
-    const isDefaultState = !(debug || info || warn || error);
-
-    const selectedKeys: string[] = [];
-
-    for (const level of ['debug', 'info', 'warn', 'error']) {
-      if (props.state.levelFilter[level]) {
-        selectedKeys.push(level);
-      }
-    }
-
-    return (
-      <Dropdown
-        open={open}
-        trigger={['click']}
-        menu={{
-          selectable: true,
-          selectedKeys: [
-            debug ? 'debug' : '',
-            info ? 'info' : '',
-            warn ? 'warn' : '',
-            error ? 'error' : '',
-          ],
-          items: [
-            {
-              label: (
-                <Space>
-                  <BugOutlined />
-                  Debug
-                </Space>
-              ),
-              onClick: () => {
-                props.state.setFilterLogLevels({ debug: !debug });
-              },
-              key: 'debug',
-            },
-            {
-              label: (
-                <Space>
-                  <InfoCircleOutlined />
-                  Info
-                </Space>
-              ),
-              onClick: () => {
-                props.state.setFilterLogLevels({ info: !info });
-              },
-              key: 'info',
-            },
-            {
-              label: (
-                <Space>
-                  <WarningOutlined />
-                  Warning
-                </Space>
-              ),
-              onClick: () => {
-                props.state.setFilterLogLevels({ warn: !warn });
-              },
-              key: 'warn',
-            },
-            {
-              label: (
-                <Space>
-                  <FireOutlined />
-                  Error
-                </Space>
-              ),
-              onClick: () => {
-                props.state.setFilterLogLevels({ error: !error });
-              },
-              key: 'error',
-            },
-            {
-              type: 'divider',
-            },
-            {
-              label: 'Reset Levels',
-              onClick: () => {
-                setOpen(false);
-                props.state.setFilterLogLevels({
-                  debug: false,
-                  info: false,
-                  warn: false,
-                  error: false,
-                });
-              },
-              key: 'reset',
-            },
-          ],
-        }}
-      >
-        <Button
-          onClick={() => setOpen(!open)}
-          icon={isDefaultState ? <FilterOutlined /> : <FilterTwoTone />}
-        />
-      </Dropdown>
-    );
-  }
-
   const systemTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const userTZ = props.state.stateFiles['log-context.json']?.data?.systemTZ;
   const tz = props.state.isUserTZ ? userTZ : systemTZ;
@@ -278,10 +170,7 @@ export const Filter = observer((props: FilterProps) => {
         ]}
       />
       <Divider type="vertical" />
-      <Space className="FilterGroup">
-        {renderFilter()}
-        {showOnlySearchResultsButton}
-      </Space>
+      <Space className="FilterGroup">{showOnlySearchResultsButton}</Space>
       <Divider type="vertical" />
       <Space.Compact className="SearchInputGroup">
         <Input

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -33,7 +33,9 @@ export const CoreApplication = observer((props: CoreAppProps) => {
   const [processedLogFiles, setProcessedLogFiles] = useState<ProcessedLogFiles>(
     {
       browser: [],
+      epic_traces: [],
       webapp: [],
+      service_worker: [],
       state: [],
       installer: [],
       netlog: [],
@@ -187,11 +189,25 @@ export const CoreApplication = observer((props: CoreAppProps) => {
         const { setMergedFile } = props.state;
 
         if (currentProcessed) {
-          const MERGE_TYPES = ['browser', 'webapp'] as const;
-          const mergeResults = await Promise.allSettled([
-            mergeLogFiles(currentProcessed.browser, LogType.BROWSER),
-            mergeLogFiles(currentProcessed.webapp, LogType.WEBAPP),
-          ]);
+          const MERGE_CANDIDATES = [
+            { key: 'browser', type: LogType.BROWSER },
+            { key: 'epic_traces', type: LogType.EPIC_TRACES },
+            { key: 'webapp', type: LogType.WEBAPP },
+            { key: 'service_worker', type: LogType.SERVICE_WORKER },
+            { key: 'chromium', type: LogType.CHROMIUM },
+            { key: 'installer', type: LogType.INSTALLER },
+          ] as const;
+          const toProcess = MERGE_CANDIDATES.map(({ key, type }) => {
+            const files = (
+              currentProcessed[
+                key as keyof typeof currentProcessed
+              ] as ProcessedLogFile[]
+            ).filter((f) => 'logEntries' in f);
+            return { key, type, files };
+          }).filter(({ files }) => files.length > 0);
+          const mergeResults = await Promise.allSettled(
+            toProcess.map(({ files, type }) => mergeLogFiles(files, type)),
+          );
 
           const failedMergeTypes: string[] = [];
           for (let i = 0; i < mergeResults.length; i++) {
@@ -199,7 +215,7 @@ export const CoreApplication = observer((props: CoreAppProps) => {
             if (result.status === 'fulfilled') {
               setMergedFile(result.value);
             } else {
-              const type = MERGE_TYPES[i];
+              const type = toProcess[i].key;
               console.error(
                 `Failed to merge ${type} log files:`,
                 result.reason,
@@ -217,9 +233,14 @@ export const CoreApplication = observer((props: CoreAppProps) => {
           }
 
           const merged = props.state.mergedLogFiles;
-          const toMerge = [merged?.browser, merged?.webapp].filter(
-            Boolean,
-          ) as MergedLogFiles[keyof MergedLogFiles][];
+          const toMerge = [
+            merged?.browser,
+            merged?.epic_traces,
+            merged?.webapp,
+            merged?.service_worker,
+            merged?.chromium,
+            merged?.installer,
+          ].filter(Boolean) as MergedLogFiles[keyof MergedLogFiles][];
 
           if (toMerge.length > 0) {
             const allMerged = await mergeLogFiles(toMerge, LogType.ALL);

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -191,7 +191,7 @@ export const CoreApplication = observer((props: CoreAppProps) => {
         if (currentProcessed) {
           const MERGE_CANDIDATES = [
             { key: 'browser', type: LogType.BROWSER },
-            { key: 'rx_epic', type: LogType.rx_epic },
+            { key: 'rx_epic', type: LogType.RX_EPIC },
             { key: 'webapp', type: LogType.WEBAPP },
             { key: 'webapp_sw', type: LogType.SERVICE_WORKER },
             { key: 'chromium', type: LogType.CHROMIUM },

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -33,9 +33,9 @@ export const CoreApplication = observer((props: CoreAppProps) => {
   const [processedLogFiles, setProcessedLogFiles] = useState<ProcessedLogFiles>(
     {
       browser: [],
-      epic_traces: [],
+      rx_epic: [],
       webapp: [],
-      service_worker: [],
+      webapp_sw: [],
       state: [],
       installer: [],
       netlog: [],
@@ -191,9 +191,9 @@ export const CoreApplication = observer((props: CoreAppProps) => {
         if (currentProcessed) {
           const MERGE_CANDIDATES = [
             { key: 'browser', type: LogType.BROWSER },
-            { key: 'epic_traces', type: LogType.EPIC_TRACES },
+            { key: 'rx_epic', type: LogType.rx_epic },
             { key: 'webapp', type: LogType.WEBAPP },
-            { key: 'service_worker', type: LogType.SERVICE_WORKER },
+            { key: 'webapp_sw', type: LogType.SERVICE_WORKER },
             { key: 'chromium', type: LogType.CHROMIUM },
             { key: 'installer', type: LogType.INSTALLER },
           ] as const;
@@ -235,9 +235,9 @@ export const CoreApplication = observer((props: CoreAppProps) => {
           const merged = props.state.mergedLogFiles;
           const toMerge = [
             merged?.browser,
-            merged?.epic_traces,
+            merged?.rx_epic,
             merged?.webapp,
-            merged?.service_worker,
+            merged?.webapp_sw,
             merged?.chromium,
             merged?.installer,
           ].filter(Boolean) as MergedLogFiles[keyof MergedLogFiles][];

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -1,21 +1,11 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 
-import {
-  Button,
-  Card,
-  Descriptions,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Typography,
-} from 'antd';
+import { Empty } from 'antd';
 import { SleuthState } from '../state/sleuth';
 import { UnzippedFile } from '../../interfaces';
 import { TraceProcessor } from '../processor/trace';
 import debug from 'debug';
-import { AreaChartOutlined } from '@ant-design/icons';
 
 export interface DevtoolsViewProps {
   state: SleuthState;
@@ -35,26 +25,16 @@ const d = debug('sleuth:devtoolsview');
  * 3. Copy the `commit` hash
  */
 export const DevtoolsView = observer((props: DevtoolsViewProps) => {
-  const [profilePid, setProfilePid] = useState<number | undefined>();
   const processorRef = useRef<TraceProcessor>(new TraceProcessor(props.file));
-
-  const prepare = useCallback(async () => {
-    if (!props.state.traceThreads) {
-      d('Preparing trace threads...');
-      props.state.traceThreads = await processorRef.current.getProcesses();
-    }
-  }, [props.state.traceThreads]);
+  const { selectedTracePid } = props.state;
 
   useEffect(() => {
-    prepare();
-  }, [prepare]);
-
-  useEffect(() => {
-    const messageHandler = async (event) => {
+    const messageHandler = async (event: MessageEvent) => {
       const iframe = document.querySelector('iframe');
-      const events = await processorRef.current.getRendererProfile(profilePid);
+      const events =
+        await processorRef.current.getRendererProfile(selectedTracePid);
       d(
-        `Loaded ${events.length} events for renderer profile with pid: ${profilePid}`,
+        `Loaded ${events.length} events for renderer profile with pid: ${selectedTracePid}`,
       );
 
       if (!iframe?.contentWindow || event.source !== iframe.contentWindow) {
@@ -74,118 +54,34 @@ export const DevtoolsView = observer((props: DevtoolsViewProps) => {
       }
     };
 
-    if (profilePid) {
+    if (selectedTracePid) {
       window.addEventListener('message', messageHandler, { once: true });
     }
 
     return () => {
       window.removeEventListener('message', messageHandler);
     };
-  }, [profilePid]);
+  }, [selectedTracePid]);
 
-  const renderThreads = () => {
-    const { traceThreads } = props.state;
-    const hasThreads = !!traceThreads?.length;
-    const isLoading = !traceThreads;
-
-    const startTime = parseInt(
-      props.file.fileName.split('.')[0]?.split('_')[4] || '0',
-      10,
-    );
-    const endTime = parseInt(
-      props.file.fileName.split('.')[0]?.split('_')[0] || '0',
-      10,
-    );
-    const duration = endTime - startTime;
-
+  if (!selectedTracePid) {
     return (
-      <Card className="ProcessTable">
-        <Space direction="vertical">
-          <Typography.Title level={3}>Performance Profile</Typography.Title>
-          <Descriptions
-            items={[
-              {
-                key: '1',
-                label: 'Duration',
-                children: (
-                  <span>
-                    {duration
-                      ? Math.floor(duration / 1000).toString()
-                      : 'unknown'}{' '}
-                    seconds
-                  </span>
-                ),
-              },
-              {
-                key: '2',
-                label: 'Trace started',
-                children: (
-                  <span>
-                    {startTime
-                      ? new Date(startTime).toLocaleString()
-                      : 'unknown'}
-                  </span>
-                ),
-              },
-              {
-                key: '3',
-                label: 'Trace ended',
-                children: (
-                  <span>
-                    {endTime ? new Date(endTime).toLocaleString() : 'unknown'}
-                  </span>
-                ),
-              },
-            ]}
-          />
-          {isLoading && <Skeleton />}
-          {!hasThreads && !isLoading ? (
-            <p>No trace threads found...</p>
-          ) : (
-            <Table
-              pagination={false}
-              dataSource={traceThreads?.map((value, index) => ({
-                key: index,
-                process: value.title || 'Unknown',
-                type: <Tag>{value.type}</Tag>,
-                pid: value.processId,
-                open: (
-                  <Button
-                    onClick={() => {
-                      setProfilePid(value.processId);
-                    }}
-                    icon={<AreaChartOutlined />}
-                  >
-                    Open
-                  </Button>
-                ),
-              }))}
-              columns={[
-                { title: 'Process Name', dataIndex: 'process', key: 'process' },
-                { title: 'Type', dataIndex: 'type', key: 'type' },
-                { title: 'PID', dataIndex: 'pid', key: 'pid' },
-                { title: 'Action', dataIndex: 'open', key: 'open' },
-              ]}
-            />
-          )}
-        </Space>
-      </Card>
-    );
-  };
-
-  if (profilePid) {
-    return (
-      <div className="Devtools">
-        <iframe
-          title="DevTools embed"
-          src={
-            'https://chrome-devtools-frontend.appspot.com/serve_file/@c545657f5084b79e2aa3ea4074ae232ce328ff2d/trace_app.html?panel=timeline'
-          }
-          frameBorder={0}
-        />
-      </div>
+      <Empty
+        description="Select a process from the sidebar to view its trace"
+        style={{ marginTop: 64 }}
+      />
     );
   }
 
-  return <div className="ProcessTableWrapper">{renderThreads()}</div>;
+  return (
+    <div className="Devtools">
+      <iframe
+        key={selectedTracePid}
+        title="DevTools embed"
+        src={
+          'https://chrome-devtools-frontend.appspot.com/serve_file/@c545657f5084b79e2aa3ea4074ae232ce328ff2d/trace_app.html?panel=timeline'
+        }
+        frameBorder={0}
+      />
+    </div>
+  );
 });

--- a/src/renderer/components/devtools-view.tsx
+++ b/src/renderer/components/devtools-view.tsx
@@ -30,26 +30,33 @@ export const DevtoolsView = observer((props: DevtoolsViewProps) => {
 
   useEffect(() => {
     const messageHandler = async (event: MessageEvent) => {
-      const iframe = document.querySelector('iframe');
-      const events =
-        await processorRef.current.getRendererProfile(selectedTracePid);
-      d(
-        `Loaded ${events.length} events for renderer profile with pid: ${selectedTracePid}`,
-      );
+      try {
+        const iframe = document.querySelector('iframe');
+        const events =
+          await processorRef.current.getRendererProfile(selectedTracePid);
+        d(
+          `Loaded ${events.length} events for renderer profile with pid: ${selectedTracePid}`,
+        );
 
-      if (!iframe?.contentWindow || event.source !== iframe.contentWindow) {
-        return;
-      }
-      if (event.data && event.data.type === 'REHYDRATING_IFRAME_READY') {
-        d('Received REHYDRATING_IFRAME_READY event from DevTools');
-        iframe.contentWindow.postMessage(
-          {
-            type: 'REHYDRATING_TRACE_FILE',
-            traceJson: JSON.stringify({
-              traceEvents: events,
-            }),
-          },
-          '*',
+        if (!iframe?.contentWindow || event.source !== iframe.contentWindow) {
+          return;
+        }
+        if (event.data && event.data.type === 'REHYDRATING_IFRAME_READY') {
+          d('Received REHYDRATING_IFRAME_READY event from DevTools');
+          iframe.contentWindow.postMessage(
+            {
+              type: 'REHYDRATING_TRACE_FILE',
+              traceJson: JSON.stringify({
+                traceEvents: events,
+              }),
+            },
+            '*',
+          );
+        }
+      } catch (error) {
+        console.error(
+          `Failed to load renderer profile for PID ${selectedTracePid}:`,
+          error,
         );
       }
     };

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -34,6 +34,7 @@ import { isReduxAction } from '../../utils/is-redux-action';
 import { LogTableProps, SortFilterListOptions } from './log-table-constants';
 import { isMergedLogFile } from '../../utils/is-logfile';
 import { getRegExpMaybeSafe } from '../../utils/regexp';
+import { matchTag } from '../../utils/match-tag';
 import { between } from '../../utils/is-between';
 import { getRangeEntries } from '../../utils/get-range-from-array';
 import { RepeatedLevels } from '../../shared-constants';
@@ -44,19 +45,6 @@ import { getCopyText } from '../state/copy';
 import { PartitionOutlined } from '@ant-design/icons';
 
 const d = debug('sleuth:logtable');
-
-/**
- * Something like `[HUDDLES]` in webapp logs
- */
-const WEBAPP_TAG_RGX = /^\s*\[([A-Za-z][A-Za-z0-9_ -]+)\]/;
-/**
- * Something like `Store:` in desktop logs
- */
-const BROWSER_PREFIX_RGX = /^\s*([A-Za-z][A-Za-z0-9_-]*(?:\s*\[[^\]]+\])?):/;
-/**
- * Something like `Tag = fooBarEpic;` for rxjs-spy debug logs
- */
-const BROWSER_EPIC_TAG_PREFIX = /^\s*Tag = ([A-Za-z][A-Za-z0-9_]*);/;
 
 const tagColorCache = new Map<string, string>();
 
@@ -86,14 +74,6 @@ function hashTagColor(tag: string, dark: boolean): string {
   const color = `hsl(${h}, ${s}%, ${l}%)`;
   tagColorCache.set(key, color);
   return color;
-}
-
-function matchTag(msg: string): RegExpExecArray | null {
-  return (
-    WEBAPP_TAG_RGX.exec(msg) ||
-    BROWSER_PREFIX_RGX.exec(msg) ||
-    BROWSER_EPIC_TAG_PREFIX.exec(msg)
-  );
 }
 
 const MSG_ICON_STYLE = {
@@ -541,22 +521,20 @@ export const LogTable = observer((props: LogTableProps) => {
    */
   const renderMessageCell = useCallback(
     ({ rowData: entry }: TableCellProps): JSX.Element | string => {
-      const display = entry.highlightMessage ?? entry.message;
-
-      // Always extract tag from the raw message so it works with highlight elements too
-      const tagMatch = matchTag(entry.message);
-      const tag = tagMatch ? tagMatch[1] : null;
-      const tagDisplay = tagMatch ? tagMatch[0].trim() : null;
-      const msgAfterTag = tagMatch
-        ? typeof display === 'string'
-          ? display.slice(tagMatch[0].length)
-          : display
-        : display;
+      // Pre-parsed tag from parsing layer, with runtime fallback
+      const tag =
+        entry.tag ??
+        (() => {
+          const m = matchTag(entry.message);
+          return m ? { name: m[1], offset: m[0].length } : null;
+        })();
+      const tagDisplay = tag ? entry.message.slice(0, tag.offset).trim() : null;
+      const msgAfterTag = tag ? entry.message.slice(tag.offset) : entry.message;
 
       const tagSpan = tag ? (
         <span
           style={{
-            color: hashTagColor(tag, state.prefersDarkColors),
+            color: hashTagColor(tag.name, state.prefersDarkColors),
             flexShrink: 0,
           }}
         >

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -34,7 +34,7 @@ import { isReduxAction } from '../../utils/is-redux-action';
 import { LogTableProps, SortFilterListOptions } from './log-table-constants';
 import { isMergedLogFile } from '../../utils/is-logfile';
 import { getRegExpMaybeSafe } from '../../utils/regexp';
-import { matchTag } from '../../utils/match-tag';
+import { matchTag, hashTagColor } from '../../utils/match-tag';
 import { between } from '../../utils/is-between';
 import { getRangeEntries } from '../../utils/get-range-from-array';
 import { RepeatedLevels } from '../../shared-constants';
@@ -45,36 +45,6 @@ import { getCopyText } from '../state/copy';
 import { PartitionOutlined } from '@ant-design/icons';
 
 const d = debug('sleuth:logtable');
-
-const tagColorCache = new Map<string, string>();
-
-/**
- * Maps a string to a hex code
- */
-export function hashTagColor(tag: string, dark: boolean): string {
-  const key = `${dark ? 'd' : 'l'}:${tag}`;
-  const cached = tagColorCache.get(key);
-  if (cached) return cached;
-
-  let hash = 0;
-  for (let i = 0; i < tag.length; i++) {
-    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  const h = ((hash % 360) + 360) % 360;
-  // Yellow-green (40–160) needs lower lightness for contrast on white backgrounds
-  // Blue-purple (220–310) needs higher lightness for contrast on dark backgrounds
-  const l = dark
-    ? h >= 220 && h < 310
-      ? 78
-      : 65
-    : h >= 40 && h < 160
-      ? 32
-      : 45;
-  const s = dark && h >= 220 && h < 310 ? 95 : 80;
-  const color = `hsl(${h}, ${s}%, ${l}%)`;
-  tagColorCache.set(key, color);
-  return color;
-}
 
 const MSG_ICON_STYLE = {
   flexShrink: 0,

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -47,7 +47,9 @@ const d = debug('sleuth:logtable');
 
 export const logColorMap: Record<ProcessableLogType, string> = {
   [LogType.BROWSER]: 'cyan',
+  [LogType.EPIC_TRACES]: 'purple',
   [LogType.WEBAPP]: 'magenta',
+  [LogType.SERVICE_WORKER]: 'orange',
   [LogType.INSTALLER]: 'green',
   [LogType.CHROMIUM]: 'geekblue',
   [LogType.MOBILE]: 'lime',
@@ -224,7 +226,11 @@ export const LogTable = observer((props: LogTableProps) => {
         (!sortDir || sortDir === SortDirection.ASC);
 
       // Check if we can bail early and just use the naked logEntries array
-      if (noSort && !shouldDoFilter && !searchText)
+      const hasLogTypeFilter =
+        isMergedLogFile(file) &&
+        file.logType === LogType.ALL &&
+        !Object.values(state.logTypeFilter).every(Boolean);
+      if (noSort && !shouldDoFilter && !searchText && !hasLogTypeFilter)
         return { list: file.logEntries, newSearchList: null };
 
       let list = file.logEntries.concat();
@@ -250,6 +256,17 @@ export const LogTable = observer((props: LogTableProps) => {
       // Filter
       if (shouldDoFilter) {
         list = list.filter(doFilter);
+      }
+
+      // LogType filter (for merged ALL view)
+      if (isMergedLogFile(file) && file.logType === LogType.ALL) {
+        const { logTypeFilter } = state;
+        const allEnabled = Object.values(logTypeFilter).every(Boolean);
+        if (!allEnabled) {
+          list = list.filter(
+            (entry) => logTypeFilter[entry.logType as ProcessableLogType],
+          );
+        }
       }
 
       // DateRange
@@ -290,6 +307,7 @@ export const LogTable = observer((props: LogTableProps) => {
     [
       logFile,
       levelFilter,
+      state.logTypeFilter,
       search,
       effectiveSortBy,
       dateRange,

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -197,13 +197,8 @@ export const LogTable = observer((props: LogTableProps) => {
           filterOrDefault.info === true &&
           filterOrDefault.warn === true &&
           filterOrDefault.error === true;
-        const allDisabled =
-          filterOrDefault.debug === false &&
-          filterOrDefault.info === false &&
-          filterOrDefault.warn === false &&
-          filterOrDefault.error === false;
 
-        return !(allEnabled || allDisabled);
+        return !allEnabled;
       }
 
       function doSearch(

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -122,7 +122,7 @@ const PROCESS_TAG_STYLE = {
 
 export const logColorMap: Record<ProcessableLogType, string> = {
   [LogType.BROWSER]: 'cyan',
-  [LogType.EPIC_TRACES]: 'purple',
+  [LogType.rx_epic]: 'purple',
   [LogType.WEBAPP]: 'magenta',
   [LogType.SERVICE_WORKER]: 'orange',
   [LogType.INSTALLER]: 'green',

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -51,7 +51,7 @@ const tagColorCache = new Map<string, string>();
 /**
  * Maps a string to a hex code
  */
-function hashTagColor(tag: string, dark: boolean): string {
+export function hashTagColor(tag: string, dark: boolean): string {
   const key = `${dark ? 'd' : 'l'}:${tag}`;
   const cached = tagColorCache.get(key);
   if (cached) return cached;
@@ -319,6 +319,15 @@ export const LogTable = observer((props: LogTableProps) => {
         }
       }
 
+      // Tag filter
+      const { selectedTags } = state;
+      if (selectedTags.length > 0) {
+        const tagSet = new Set(selectedTags);
+        list = list.filter(
+          (entry) => entry.tag?.name && tagSet.has(entry.tag.name),
+        );
+      }
+
       // DateRange
       if (range) {
         d(
@@ -358,6 +367,7 @@ export const LogTable = observer((props: LogTableProps) => {
       logFile,
       levelFilter,
       state.logTypeFilter,
+      state.selectedTags,
       search,
       effectiveSortBy,
       dateRange,

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -102,7 +102,7 @@ const PROCESS_TAG_STYLE = {
 
 export const logColorMap: Record<ProcessableLogType, string> = {
   [LogType.BROWSER]: 'cyan',
-  [LogType.rx_epic]: 'purple',
+  [LogType.RX_EPIC]: 'purple',
   [LogType.WEBAPP]: 'magenta',
   [LogType.SERVICE_WORKER]: 'orange',
   [LogType.INSTALLER]: 'green',
@@ -280,7 +280,14 @@ export const LogTable = observer((props: LogTableProps) => {
         isMergedLogFile(file) &&
         file.logType === LogType.ALL &&
         !Object.values(state.logTypeFilter).every(Boolean);
-      if (noSort && !shouldDoFilter && !searchText && !hasLogTypeFilter)
+      const hasTagFilter = state.selectedTags.length > 0;
+      if (
+        noSort &&
+        !shouldDoFilter &&
+        !searchText &&
+        !hasLogTypeFilter &&
+        !hasTagFilter
+      )
         return { list: file.logEntries, newSearchList: null };
 
       let list = file.logEntries.concat();

--- a/src/renderer/components/sidebar/sidebar-checkbox-group.tsx
+++ b/src/renderer/components/sidebar/sidebar-checkbox-group.tsx
@@ -1,0 +1,165 @@
+import { Checkbox, Space, Typography } from 'antd';
+import React, { useState } from 'react';
+
+export interface CheckboxItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  count?: number;
+}
+
+interface SidebarCheckboxGroupProps {
+  title: string;
+  items: CheckboxItem[];
+  filter: Record<string, boolean>;
+  onToggle: (key: string, checked: boolean) => void;
+  onFocus: (key: string) => void;
+  onShowAll: () => void;
+  /** When is "all shown"? 'all-true' = all checked means all shown (log types).
+   *  'all-false' = all unchecked means all shown (log levels). */
+  allShownWhen: 'all-true' | 'all-false';
+}
+
+export function SidebarCheckboxGroup({
+  title,
+  items,
+  filter,
+  onToggle,
+  onFocus,
+  onShowAll,
+  allShownWhen,
+}: SidebarCheckboxGroupProps) {
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  const allShown =
+    allShownWhen === 'all-true'
+      ? items.every(({ key }) => filter[key])
+      : items.every(({ key }) => !filter[key]);
+
+  return (
+    <fieldset
+      style={{
+        border: 'none',
+        borderTop: '1px solid var(--ant-color-border)',
+        margin: 0,
+        padding: '4px 0 12px',
+      }}
+    >
+      <legend
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 8,
+          padding: '0 4px 0 0',
+          margin: 0,
+        }}
+      >
+        <Typography.Text
+          type="secondary"
+          style={{
+            fontSize: 11,
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+          }}
+        >
+          {title}
+        </Typography.Text>
+        {!allShown && (
+          <Typography.Text
+            strong
+            style={{
+              fontSize: 11,
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              cursor: 'pointer',
+            }}
+            onClick={onShowAll}
+          >
+            Show all
+          </Typography.Text>
+        )}
+      </legend>
+      {items.map(({ key, label, icon, count }) => {
+        const isHovered = hoveredKey === key;
+        return (
+          <div
+            key={key}
+            style={{
+              padding: '1px 4px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              borderRadius: 4,
+              cursor: 'pointer',
+              background: isHovered
+                ? 'var(--ant-color-fill-secondary)'
+                : 'transparent',
+              transition: 'background 0.15s ease',
+            }}
+            onMouseEnter={() => setHoveredKey(key)}
+            onMouseLeave={() => setHoveredKey(null)}
+            onClick={() => onFocus(key)}
+          >
+            <Checkbox
+              checked={filter[key]}
+              onChange={(e) => {
+                e.stopPropagation();
+                onToggle(key, e.target.checked);
+              }}
+              onClick={(e) => e.stopPropagation()}
+            />
+            <Space size={4} style={{ flex: 1 }}>
+              {icon}
+              <Typography.Text style={{ fontSize: 14 }}>
+                {label}
+              </Typography.Text>
+            </Space>
+            <span
+              style={{
+                position: 'relative',
+                minWidth: 36,
+                textAlign: 'right',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+              }}
+            >
+              {count !== undefined && (
+                <Typography.Text
+                  type="secondary"
+                  style={{
+                    fontSize: 14,
+                    opacity: isHovered ? 0 : 1,
+                    transition: 'opacity 0.15s ease',
+                  }}
+                >
+                  {count >= 1000
+                    ? `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
+                    : count}
+                </Typography.Text>
+              )}
+              <Typography.Text
+                strong
+                style={{
+                  fontSize: 11,
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.5,
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                  opacity: isHovered ? 1 : 0,
+                  transition: 'opacity 0.15s ease',
+                  color: 'var(--ant-color-primary)',
+                }}
+              >
+                ONLY
+              </Typography.Text>
+            </span>
+          </div>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/src/renderer/components/sidebar/sidebar-checkbox-group.tsx
+++ b/src/renderer/components/sidebar/sidebar-checkbox-group.tsx
@@ -37,42 +37,18 @@ export function SidebarCheckboxGroup({
       : items.every(({ key }) => !filter[key]);
 
   return (
-    <fieldset
-      style={{
-        border: 'none',
-        borderTop: '1px solid var(--ant-color-border)',
-        margin: 0,
-        padding: '4px 0 12px',
-      }}
-    >
-      <legend
-        style={{
-          display: 'flex',
-          alignItems: 'baseline',
-          gap: 8,
-          padding: '0 4px 0 0',
-          margin: 0,
-        }}
-      >
+    <fieldset className="SidebarCheckboxGroup">
+      <legend className="SidebarCheckboxGroup-legend">
         <Typography.Text
           type="secondary"
-          style={{
-            fontSize: 11,
-            textTransform: 'uppercase',
-            letterSpacing: 0.5,
-          }}
+          className="SidebarCheckboxGroup-title"
         >
           {title}
         </Typography.Text>
         {!allShown && (
           <Typography.Text
             strong
-            style={{
-              fontSize: 11,
-              textTransform: 'uppercase',
-              letterSpacing: 0.5,
-              cursor: 'pointer',
-            }}
+            className="SidebarCheckboxGroup-showAll"
             onClick={onShowAll}
           >
             Show all
@@ -84,18 +60,7 @@ export function SidebarCheckboxGroup({
         return (
           <div
             key={key}
-            style={{
-              padding: '1px 4px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              borderRadius: 4,
-              cursor: 'pointer',
-              background: isHovered
-                ? 'var(--ant-color-fill-secondary)'
-                : 'transparent',
-              transition: 'background 0.15s ease',
-            }}
+            className="SidebarCheckboxGroup-row"
             onMouseEnter={() => setHoveredKey(key)}
             onMouseLeave={() => setHoveredKey(null)}
             onClick={() => onFocus(key)}
@@ -110,28 +75,16 @@ export function SidebarCheckboxGroup({
             />
             <Space size={4} style={{ flex: 1 }}>
               {icon}
-              <Typography.Text style={{ fontSize: 14 }}>
+              <Typography.Text className="SidebarCheckboxGroup-label">
                 {label}
               </Typography.Text>
             </Space>
-            <span
-              style={{
-                position: 'relative',
-                minWidth: 36,
-                textAlign: 'right',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'flex-end',
-              }}
-            >
+            <span className="SidebarCheckboxGroup-countWrap">
               {count !== undefined && (
                 <Typography.Text
                   type="secondary"
-                  style={{
-                    fontSize: 14,
-                    opacity: isHovered ? 0 : 1,
-                    transition: 'opacity 0.15s ease',
-                  }}
+                  className="SidebarCheckboxGroup-count"
+                  style={{ opacity: isHovered ? 0 : 1 }}
                 >
                   {count >= 1000
                     ? `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
@@ -140,19 +93,8 @@ export function SidebarCheckboxGroup({
               )}
               <Typography.Text
                 strong
-                style={{
-                  fontSize: 11,
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.5,
-                  position: 'absolute',
-                  inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'flex-end',
-                  opacity: isHovered ? 1 : 0,
-                  transition: 'opacity 0.15s ease',
-                  color: 'var(--ant-color-primary)',
-                }}
+                className="SidebarCheckboxGroup-only"
+                style={{ opacity: isHovered ? 1 : 0 }}
               >
                 ONLY
               </Typography.Text>

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -494,30 +494,11 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                   allShownWhen="all-true"
                 />
                 {tagOptions.length > 0 && (
-                  <fieldset
-                    style={{
-                      border: 'none',
-                      borderTop: '1px solid var(--ant-color-border)',
-                      margin: 0,
-                      padding: '4px 0 12px',
-                    }}
-                  >
-                    <legend
-                      style={{
-                        padding: '0 4px 0 0',
-                        margin: 0,
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 8,
-                      }}
-                    >
+                  <fieldset className="SidebarTags">
+                    <legend className="SidebarTags-legend">
                       <Typography.Text
                         type="secondary"
-                        style={{
-                          fontSize: 11,
-                          textTransform: 'uppercase',
-                          letterSpacing: 0.5,
-                        }}
+                        className="SidebarCheckboxGroup-title"
                       >
                         Tags
                       </Typography.Text>
@@ -529,7 +510,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                           { label: '#', value: 'freq' },
                           { label: 'Az', value: 'az' },
                         ]}
-                        style={{ fontSize: 10 }}
+                        className="SidebarTags-sortToggle"
                       />
                     </legend>
                     <Select
@@ -538,10 +519,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                       options={tagOptions}
                       value={props.state.selectedTags}
                       onChange={(tags) => props.state.setSelectedTags(tags)}
-                      style={{
-                        width: '100%',
-                        fontFamily: 'Fira Code, monospace',
-                      }}
+                      className="SidebarTags-select"
                       size="small"
                       allowClear
                       optionRender={(option) => {
@@ -554,33 +532,18 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                             : '';
                         return (
                           <span
+                            className="SidebarTags-option"
                             style={{
-                              display: 'flex',
-                              justifyContent: 'space-between',
-                              fontFamily: 'Fira Code, monospace',
                               color: hashTagColor(
                                 String(option.value ?? ''),
                                 props.state.prefersDarkColors,
                               ),
                             }}
                           >
-                            <span
-                              style={{
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                minWidth: 0,
-                              }}
-                            >
+                            <span className="SidebarTags-optionLabel">
                               {option.label}
                             </span>
-                            <span
-                              style={{
-                                opacity: 0.5,
-                                flexShrink: 0,
-                                marginLeft: 8,
-                              }}
-                            >
+                            <span className="SidebarTags-optionCount">
                               {countLabel}
                             </span>
                           </span>
@@ -588,37 +551,19 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                       }}
                       tagRender={({ label, value, closable, onClose }) => (
                         <span
+                          className="SidebarTags-tag"
                           style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 4,
-                            maxWidth: 160,
-                            padding: '0 4px',
-                            borderRadius: 4,
-                            border: '1px solid var(--ant-color-border)',
-                            marginInlineEnd: 4,
-                            fontSize: 12,
-                            fontFamily: 'Fira Code, monospace',
                             color: hashTagColor(
                               String(value ?? ''),
                               props.state.prefersDarkColors,
                             ),
                           }}
                         >
-                          <span
-                            style={{
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                              minWidth: 0,
-                            }}
-                          >
-                            {label}
-                          </span>
+                          <span className="SidebarTags-tagLabel">{label}</span>
                           {closable && (
                             <span
+                              className="SidebarTags-tagClose"
                               onClick={onClose}
-                              style={{ cursor: 'pointer', marginLeft: 2 }}
                             >
                               ×
                             </span>

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -2,8 +2,10 @@ import {
   Badge,
   Segmented,
   Select,
+  Skeleton,
   Space,
   Tabs,
+  Tag,
   theme,
   Tooltip,
   Tree,
@@ -21,13 +23,16 @@ import {
   ProcessableLogType,
   ProcessedLogFile,
   SelectableLogType,
+  TRACE_VIEWER,
   UnzippedFile,
   LogTypeFilter,
 } from '../../../interfaces';
 import {
   ApartmentOutlined,
+  ApiOutlined,
   ChromeOutlined,
   CloudOutlined,
+  DashboardOutlined,
   CommentOutlined,
   DesktopOutlined,
   DownloadOutlined,
@@ -49,7 +54,8 @@ import { isMergedLogFile } from '../../../utils/is-logfile';
 import { getEnvironmentWarnings } from '../../analytics/environment-analytics';
 import { getRootStateWarnings } from '../../analytics/root-state-analytics';
 import { getTraceWarnings } from '../../analytics/trace-analytics';
-import { hashTagColor } from '../log-table';
+import { hashTagColor, logColorMap } from '../log-table';
+import { TraceProcessor } from '../../processor/trace';
 
 interface SidebarFileTreeProps {
   state: SleuthState;
@@ -153,6 +159,45 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     [props.state, files],
   );
 
+  // Load trace threads when trace files are available
+  useEffect(() => {
+    const traceFiles = props.state.processedLogFiles?.trace;
+    if (!traceFiles?.length || props.state.traceThreads) return;
+    const processor = new TraceProcessor(traceFiles[0]);
+    processor.getProcesses().then((threads) => {
+      props.state.traceThreads = threads;
+    });
+  }, [props.state.processedLogFiles?.trace, props.state.traceThreads]);
+
+  const onTraceSelect = useCallback(
+    (selectedKeys: Key[]) => {
+      const selected = String(selectedKeys[0]);
+      if (selected === TRACE_VIEWER.PERFETTO) {
+        props.state.openTraceViewer(TRACE_VIEWER.PERFETTO);
+      } else {
+        // Thread PID — open DevTools with that process
+        const pid = parseInt(selected, 10);
+        if (!isNaN(pid)) {
+          props.state.openTraceViewer(TRACE_VIEWER.CHROME_DEVTOOLS);
+          props.state.setSelectedTracePid(pid);
+        }
+      }
+    },
+    [props.state],
+  );
+
+  const onNetlogSelect = useCallback(
+    (fileId: string) => {
+      const file = props.state.processedLogFiles?.netlog?.find(
+        (f) => f.id === fileId,
+      );
+      if (file) {
+        props.state.selectLogFile(file);
+      }
+    },
+    [props.state],
+  );
+
   // --- Log type callbacks ---
   const onLogTypeToggle = useCallback(
     (key: string, checked: boolean) => {
@@ -253,7 +298,20 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
   const isStateFileSelected = selectedKey
     ? stateNodes.some((node) => node.key === selectedKey)
     : false;
-  const derivedTab = isStateFileSelected ? 'state' : 'logs';
+  const isTraceFileSelected =
+    selectedLogFile &&
+    'fileName' in selectedLogFile &&
+    selectedLogFile.fileName.endsWith('.trace');
+  const isNetlogFileSelected = selectedKey
+    ? (processedLogFiles?.netlog?.some((f) => f.id === selectedKey) ?? false)
+    : false;
+  const derivedTab = isNetlogFileSelected
+    ? 'netlog'
+    : isTraceFileSelected
+      ? 'trace'
+      : isStateFileSelected
+        ? 'state'
+        : 'logs';
   const activeTab = manualTab ?? derivedTab;
 
   // Compute log level line counts across all processable files
@@ -463,7 +521,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
         activeKey={activeTab}
         onChange={(key) => {
           setManualTab(key);
-          if (key === 'logs' && isStateFileSelected) {
+          if (key === 'logs' && derivedTab !== 'logs') {
             props.state.selectLogFile(null, LogType.ALL);
           }
         }}
@@ -598,7 +656,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
           },
           {
             key: 'state',
-            label: 'State & Settings',
+            label: 'State',
             icon: <SettingOutlined />,
             children: (
               <Tree
@@ -609,6 +667,146 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
               />
             ),
           },
+          ...(processedLogFiles?.netlog?.length
+            ? [
+                {
+                  key: 'netlog',
+                  label: 'Net',
+                  icon: <ApiOutlined />,
+                  children: (
+                    <fieldset className="SidebarCheckboxGroup">
+                      <legend className="SidebarCheckboxGroup-legend">
+                        <Typography.Text
+                          type="secondary"
+                          className="SidebarCheckboxGroup-title"
+                        >
+                          Network Logs
+                        </Typography.Text>
+                      </legend>
+                      {processedLogFiles.netlog.map((file) => {
+                        const isSelected =
+                          isNetlogFileSelected && selectedKey === file.id;
+                        return (
+                          <div
+                            key={file.id}
+                            className={classNames('SidebarCheckboxGroup-row', {
+                              selected: isSelected,
+                            })}
+                            onClick={() => onNetlogSelect(file.id)}
+                          >
+                            <Space size={4} style={{ flex: 1 }}>
+                              <GlobalOutlined />
+                              <Typography.Text className="SidebarCheckboxGroup-label">
+                                {file.fileName}
+                              </Typography.Text>
+                            </Space>
+                          </div>
+                        );
+                      })}
+                    </fieldset>
+                  ),
+                },
+              ]
+            : []),
+          ...(processedLogFiles?.trace?.length
+            ? [
+                {
+                  key: 'trace',
+                  label: 'Trace',
+                  icon: <DashboardOutlined />,
+                  children: (
+                    <>
+                      <fieldset className="SidebarCheckboxGroup">
+                        <legend className="SidebarCheckboxGroup-legend">
+                          <Typography.Text
+                            type="secondary"
+                            className="SidebarCheckboxGroup-title"
+                          >
+                            Chrome DevTools
+                          </Typography.Text>
+                        </legend>
+                        {!props.state.traceThreads && (
+                          <Skeleton
+                            active
+                            paragraph={{ rows: 2 }}
+                            title={false}
+                          />
+                        )}
+                        {props.state.traceThreads?.map((thread) => {
+                          const isSelected =
+                            isTraceFileSelected &&
+                            props.state.selectedTraceViewer ===
+                              TRACE_VIEWER.CHROME_DEVTOOLS &&
+                            props.state.selectedTracePid === thread.processId;
+                          return (
+                            <div
+                              key={thread.processId}
+                              className={classNames(
+                                'SidebarCheckboxGroup-row',
+                                { selected: isSelected },
+                              )}
+                              onClick={() =>
+                                onTraceSelect([String(thread.processId)])
+                              }
+                            >
+                              <Space size={4} style={{ flex: 1 }}>
+                                <ChromeOutlined />
+                                <Typography.Text className="SidebarCheckboxGroup-label">
+                                  {thread.title || `PID ${thread.processId}`}
+                                </Typography.Text>
+                              </Space>
+                              <Tag
+                                color={
+                                  thread.type === 'renderer'
+                                    ? logColorMap[LogType.WEBAPP]
+                                    : logColorMap[LogType.BROWSER]
+                                }
+                                style={{
+                                  fontSize: 10,
+                                  lineHeight: '16px',
+                                  padding: '0 4px',
+                                  margin: 0,
+                                }}
+                              >
+                                {thread.type === 'renderer'
+                                  ? 'webapp'
+                                  : thread.type}
+                              </Tag>
+                            </div>
+                          );
+                        })}
+                      </fieldset>
+                      <fieldset className="SidebarCheckboxGroup">
+                        <legend className="SidebarCheckboxGroup-legend">
+                          <Typography.Text
+                            type="secondary"
+                            className="SidebarCheckboxGroup-title"
+                          >
+                            Perfetto
+                          </Typography.Text>
+                        </legend>
+                        <div
+                          className={classNames('SidebarCheckboxGroup-row', {
+                            selected:
+                              isTraceFileSelected &&
+                              props.state.selectedTraceViewer ===
+                                TRACE_VIEWER.PERFETTO,
+                          })}
+                          onClick={() => onTraceSelect([TRACE_VIEWER.PERFETTO])}
+                        >
+                          <Space size={4} style={{ flex: 1 }}>
+                            <DashboardOutlined />
+                            <Typography.Text className="SidebarCheckboxGroup-label">
+                              Open in Perfetto
+                            </Typography.Text>
+                          </Space>
+                        </div>
+                      </fieldset>
+                    </>
+                  ),
+                },
+              ]
+            : []),
         ]}
       />
     </div>

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -63,22 +63,22 @@ interface LogTypeCheckboxConfig {
 const LOG_TYPE_CHECKBOXES: LogTypeCheckboxConfig[] = [
   {
     type: LogType.BROWSER,
-    label: 'Browser',
+    label: 'browser',
     icon: <DesktopOutlined />,
   },
-  { type: LogType.WEBAPP, label: 'Webapp', icon: <CommentOutlined /> },
+  { type: LogType.WEBAPP, label: 'webapp', icon: <CommentOutlined /> },
   {
     type: LogType.SERVICE_WORKER,
-    label: 'Service worker',
+    label: 'service worker',
     icon: <CloudOutlined />,
   },
   {
-    type: LogType.EPIC_TRACES,
-    label: 'Epic traces',
+    type: LogType.rx_epic,
+    label: 'epic traces',
     icon: <ExperimentOutlined />,
   },
-  { type: LogType.CHROMIUM, label: 'Chromium', icon: <ChromeOutlined /> },
-  { type: LogType.INSTALLER, label: 'Installer', icon: <DownloadOutlined /> },
+  { type: LogType.CHROMIUM, label: 'chromium', icon: <ChromeOutlined /> },
+  { type: LogType.INSTALLER, label: 'installer', icon: <DownloadOutlined /> },
 ];
 
 const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
@@ -144,6 +144,13 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     },
     [props.state],
   );
+
+  const onShowAll = useCallback(() => {
+    const filter = Object.fromEntries(
+      LOG_TYPE_CHECKBOXES.map(({ type }) => [type, true]),
+    ) as Partial<LogTypeFilter>;
+    props.state.setLogTypeFilter(filter);
+  }, [props.state]);
 
   const onLogTypeFocus = useCallback(
     (logType: ProcessableLogType) => {
@@ -341,18 +348,41 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             icon: <FileTextOutlined />,
             children: (
               <div style={{ padding: '4px 0' }}>
-                <Typography.Text
-                  type="secondary"
+                <div
                   style={{
-                    fontSize: 11,
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.5,
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    justifyContent: 'space-between',
                     padding: '2px 4px 4px',
-                    display: 'block',
                   }}
                 >
-                  Log Types
-                </Typography.Text>
+                  <Typography.Text
+                    type="secondary"
+                    style={{
+                      fontSize: 11,
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.5,
+                    }}
+                  >
+                    Log Types
+                  </Typography.Text>
+                  {!availableLogTypes.every(
+                    ({ type }) => logTypeFilter[type],
+                  ) && (
+                    <Typography.Text
+                      strong
+                      style={{
+                        fontSize: 11,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        cursor: 'pointer',
+                      }}
+                      onClick={onShowAll}
+                    >
+                      Show all
+                    </Typography.Text>
+                  )}
+                </div>
                 {availableLogTypes.map(({ type, label, icon }) => {
                   const files =
                     (processedLogFiles?.[
@@ -399,8 +429,11 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                       <span
                         style={{
                           position: 'relative',
-                          minWidth: 32,
+                          minWidth: 36,
                           textAlign: 'right',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'flex-end',
                         }}
                       >
                         <Typography.Text
@@ -414,20 +447,22 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                           {lineCount.toLocaleString()}
                         </Typography.Text>
                         <Typography.Text
-                          type="secondary"
+                          strong
                           style={{
                             fontSize: 11,
-                            fontWeight: 600,
                             textTransform: 'uppercase',
                             letterSpacing: 0.5,
                             position: 'absolute',
-                            right: 0,
-                            top: 0,
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'flex-end',
                             opacity: isHovered ? 1 : 0,
                             transition: 'opacity 0.15s ease',
+                            color: 'var(--ant-color-primary)',
                           }}
                         >
-                          only
+                          ONLY
                         </Typography.Text>
                       </span>
                     </div>

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -75,7 +75,7 @@ const LOG_TYPE_CHECKBOXES: CheckboxItem[] = [
     icon: <CloudOutlined />,
   },
   {
-    key: LogType.rx_epic,
+    key: LogType.RX_EPIC,
     label: 'epic traces',
     icon: <ExperimentOutlined />,
   },
@@ -164,9 +164,15 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     const traceFiles = props.state.processedLogFiles?.trace;
     if (!traceFiles?.length || props.state.traceThreads) return;
     const processor = new TraceProcessor(traceFiles[0]);
-    processor.getProcesses().then((threads) => {
-      props.state.traceThreads = threads;
-    });
+    processor
+      .getProcesses()
+      .then((threads) => {
+        props.state.setTraceThreads(threads);
+      })
+      .catch((error) => {
+        console.error('Failed to load trace threads:', error);
+        props.state.setTraceThreads([]);
+      });
   }, [props.state.processedLogFiles?.trace, props.state.traceThreads]);
 
   const onTraceSelect = useCallback(

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -1,5 +1,6 @@
 import {
   Badge,
+  Checkbox,
   Space,
   Tabs,
   Tooltip,
@@ -13,16 +14,16 @@ import React, { Key, useCallback, useEffect, useState } from 'react';
 import { SleuthState } from '../../state/sleuth';
 import {
   LogType,
+  ProcessableLogType,
   ProcessedLogFile,
   SelectableLogType,
-  TRACE_VIEWER,
   UnzippedFile,
 } from '../../../interfaces';
 import {
   ApartmentOutlined,
   ChromeOutlined,
+  CloudOutlined,
   CommentOutlined,
-  DashboardOutlined,
   DesktopOutlined,
   DownloadOutlined,
   DownOutlined,
@@ -33,22 +34,14 @@ import {
   GlobalOutlined,
   HeartOutlined,
   MacCommandOutlined,
-  MergeOutlined,
-  MobileOutlined,
   NotificationOutlined,
   PictureOutlined,
   SettingOutlined,
-  SlidersOutlined,
   WarningFilled,
-  WifiOutlined,
 } from '@ant-design/icons';
-import { truncate } from '../../../utils/truncate-string';
-import { isMergedLogFile, isProcessedLogFile } from '../../../utils/is-logfile';
+import { isMergedLogFile } from '../../../utils/is-logfile';
 import { getEnvironmentWarnings } from '../../analytics/environment-analytics';
 import { getRootStateWarnings } from '../../analytics/root-state-analytics';
-import { levelsHave } from '../../../utils/level-counts';
-import { countExcessiveRepeats } from '../../../utils/count-excessive-repeats';
-import { plural } from '../../../utils/pluralize';
 import { getTraceWarnings } from '../../analytics/trace-analytics';
 
 interface SidebarFileTreeProps {
@@ -60,11 +53,36 @@ interface SidebarNodeData {
   type: SelectableLogType;
 }
 
+interface LogTypeCheckboxConfig {
+  type: ProcessableLogType;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const LOG_TYPE_CHECKBOXES: LogTypeCheckboxConfig[] = [
+  {
+    type: LogType.BROWSER,
+    label: 'Browser Process',
+    icon: <DesktopOutlined />,
+  },
+  {
+    type: LogType.EPIC_TRACES,
+    label: 'Epic Traces',
+    icon: <ExperimentOutlined />,
+  },
+  { type: LogType.WEBAPP, label: 'WebApp', icon: <CommentOutlined /> },
+  {
+    type: LogType.SERVICE_WORKER,
+    label: 'Service Worker',
+    icon: <CloudOutlined />,
+  },
+  { type: LogType.CHROMIUM, label: 'Chromium', icon: <ChromeOutlined /> },
+  { type: LogType.INSTALLER, label: 'Installer', icon: <DownloadOutlined /> },
+];
+
 const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
   const [stateNodes, setStateNodes] = useState<TreeDataNode[]>([]);
-  const [logNodes, setLogNodes] = useState<TreeDataNode[]>([]);
   const [expandedStateKeys, setExpandedStateKeys] = useState<Key[]>();
-  const [expandedLogKeys, setExpandedLogKeys] = useState<Key[]>();
   const [files, setFiles] = useState<
     Map<string, ProcessedLogFile | UnzippedFile>
   >(new Map());
@@ -85,135 +103,46 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
         }),
       );
 
-      const LOG_NODES: TreeDataNode[] = [
-        {
-          key: LogType.ALL,
-          title: <Typography.Text strong>All Desktop Logs</Typography.Text>,
-          icon: <MergeOutlined />,
-        },
-        {
-          key: LogType.BROWSER,
-          icon: <DesktopOutlined />,
-          title: <Typography.Text strong>Browser Process</Typography.Text>,
-          children: processedLogFiles.browser.map((file) => {
-            filesMap.set(file.id, file);
-            return getLogFileNode(file);
-          }),
-        },
-        ...(processedLogFiles.trace.length > 0
-          ? [
-              {
-                key: LogType.TRACE,
-                icon: <SlidersOutlined />,
-                selectable: false,
-                title: <Typography.Text strong>Trace</Typography.Text>,
-                children: [
-                  {
-                    key: TRACE_VIEWER.CHROME_DEVTOOLS,
-                    icon: <ChromeOutlined />,
-                    title: 'Chrome DevTools',
-                  },
-                  {
-                    key: TRACE_VIEWER.PERFETTO,
-                    icon: <DashboardOutlined />,
-                    title: 'Perfetto',
-                  },
-                ],
-              },
-            ]
-          : []),
-        {
-          key: LogType.CHROMIUM,
-          icon: <ChromeOutlined />,
-          title: <Typography.Text strong>Chromium</Typography.Text>,
-          children: processedLogFiles.chromium.map((file) => {
-            filesMap.set(file.id, file);
-            return getLogFileNode(file);
-          }),
-        },
-        {
-          key: LogType.WEBAPP,
-          icon: <CommentOutlined />,
-          title: <Typography.Text strong>WebApp</Typography.Text>,
-          children: processedLogFiles.webapp.map((file) => {
-            filesMap.set(file.id, file);
-            return getLogFileNode(file);
-          }),
-        },
-        {
-          key: LogType.INSTALLER,
-          icon: <DownloadOutlined />,
-          selectable: false,
-          title: <Typography.Text strong>Installer</Typography.Text>,
-          children: processedLogFiles.installer.map((file) => {
-            filesMap.set(file.id, file);
-            return getInstallerFileNode(file);
-          }),
-        },
-        ...processedLogFiles.netlog.map((file, i) => {
-          filesMap.set(file.id, file);
-          return getNetlogFileNode(file, i, processedLogFiles.netlog.length);
-        }),
-        {
-          key: LogType.MOBILE,
-          icon: <MobileOutlined />,
-          title: <Typography.Text strong>Mobile</Typography.Text>,
-          children: processedLogFiles.mobile.map((file) => {
-            filesMap.set(file.id, file);
-            return getLogFileNode(file);
-          }),
-        },
-      ];
-
-      const hasDesktopLogs =
-        processedLogFiles.browser.length > 0 ||
-        processedLogFiles.webapp.length > 0;
-
-      const visibleLogNodes = LOG_NODES.filter((node) => {
-        if (node.key === LogType.ALL) return hasDesktopLogs;
-        // Leaf nodes (no children array) are always visible
-        if (!node.children) return true;
-        return node.children.length > 0;
-      });
-
       setFiles(filesMap);
       setStateNodes(stateFileNodes);
-      setLogNodes(visibleLogNodes);
-      setExpandedLogKeys(visibleLogNodes.map((node) => node.key as Key));
     }
     fetchTree().catch((error) => {
       console.error('Failed to build sidebar file tree:', error);
     });
   }, [props.state.processedLogFiles]);
 
-  const onSelect = useCallback(
+  const onStateSelect = useCallback(
     (selectedKeys: Key[]) => {
-      // only one node can be selected at a time
       const selected = String(selectedKeys[0]);
       setManualTab(null);
 
-      if (selected === TRACE_VIEWER.CHROME_DEVTOOLS) {
-        props.state.openTraceViewer(TRACE_VIEWER.CHROME_DEVTOOLS);
-        return;
-      } else if (selected === TRACE_VIEWER.PERFETTO) {
-        props.state.openTraceViewer(TRACE_VIEWER.PERFETTO);
-        return;
-      }
-
-      if (Object.values(LogType).includes(selected as SelectableLogType)) {
-        props.state.selectLogFile(null, selected as SelectableLogType);
-      } else {
-        const file = files.get(selected);
-
-        if (file) {
-          props.state.selectLogFile(file);
-        }
+      const file = files.get(selected);
+      if (file) {
+        props.state.selectLogFile(file);
       }
     },
     [props.state, files],
   );
 
-  const { isSidebarOpen, selectedLogFile } = props.state;
+  const onLogTypeToggle = useCallback(
+    (logType: ProcessableLogType, checked: boolean) => {
+      props.state.setLogTypeFilter({ [logType]: checked });
+
+      // Ensure the ALL merged view is selected
+      const { selectedLogFile } = props.state;
+      if (
+        !selectedLogFile ||
+        !isMergedLogFile(selectedLogFile) ||
+        selectedLogFile.logType !== LogType.ALL
+      ) {
+        props.state.selectLogFile(null, LogType.ALL);
+      }
+    },
+    [props.state],
+  );
+
+  const { isSidebarOpen, selectedLogFile, logTypeFilter, processedLogFiles } =
+    props.state;
 
   function getSelectedKey(): string | undefined {
     if (!selectedLogFile) return undefined;
@@ -229,6 +158,13 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     : false;
   const derivedTab = isStateFileSelected ? 'state' : 'logs';
   const activeTab = manualTab ?? derivedTab;
+
+  // Determine which log types have files present
+  const availableLogTypes = LOG_TYPE_CHECKBOXES.filter(({ type }) => {
+    if (!processedLogFiles) return false;
+    const key = type as keyof typeof processedLogFiles;
+    return processedLogFiles[key]?.length > 0;
+  });
 
   function getNode(
     id: string,
@@ -286,73 +222,6 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     }
 
     return getNode(label, { file }, options);
-  }
-
-  function getNetlogFileNode(
-    file: UnzippedFile,
-    i: number,
-    total: number,
-  ): TreeDataNode {
-    const text = total > 1 ? `Net Log ${i + 1}` : 'Net Log';
-    return getNode(
-      text,
-      { file },
-      {
-        icon: <WifiOutlined />,
-        title: <Typography.Text strong>{text}</Typography.Text>,
-      },
-    );
-  }
-
-  function getInstallerFileNode(
-    file: UnzippedFile | ProcessedLogFile,
-  ): TreeDataNode {
-    const name = isProcessedLogFile(file)
-      ? file.logFile.fileName
-      : file.fileName;
-    const truncated = truncate(name, 24);
-
-    const options: Partial<TreeDataNode> = {};
-
-    // Check ShipItState.plist for launchAfterInstallation warning
-    if (name.toLowerCase() === 'shipitstate.plist') {
-      const stateData = props.state.stateFiles[name]?.data;
-      if (stateData && stateData.launchAfterInstallation === false) {
-        options.title = (
-          <Space>
-            <span>{truncated}</span>
-            <Tooltip
-              title="launchAfterInstallation is false - Slack may be in an update loop"
-              placement="right"
-            >
-              <WarningFilled style={{ color: 'goldenrod' }} />
-            </Tooltip>
-          </Space>
-        );
-      }
-    }
-
-    return getNode(truncated, { file }, options);
-  }
-
-  function getLogFileNode(file: ProcessedLogFile): TreeDataNode {
-    const name = truncate(file.logFile.fileName, 24);
-
-    const options: Partial<TreeDataNode> = {
-      title: name,
-    };
-
-    const hints = getLogNodeHint(file);
-    if (hints) {
-      options.title = (
-        <Space>
-          <span>{name}</span>
-          {hints}
-        </Space>
-      );
-    }
-
-    return getNode(name, { file }, options);
   }
 
   async function getStateFileHint(file: UnzippedFile) {
@@ -419,48 +288,9 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     return null;
   }
 
-  function getLogNodeHint(file: ProcessedLogFile): JSX.Element | null {
-    const { levelCounts, repeatedCounts } = file;
-    const hasErrors = levelsHave('error', levelCounts);
-    const hasWarnings = levelsHave('warn', levelCounts);
-    const excessiveRepeats = countExcessiveRepeats(repeatedCounts);
-
-    if (!hasErrors && !hasWarnings && !excessiveRepeats) {
-      return null;
-    }
-
-    // Check for errors
-    let content = hasErrors
-      ? `This file contains ${levelCounts.error} errors`
-      : '';
-
-    if (levelsHave('warn', levelCounts)) {
-      content += hasErrors
-        ? ` and ${levelCounts.warn} warnings.`
-        : `This file contains ${levelCounts.warn} warnings.`;
-    }
-
-    // Check for excessive repeats
-    if (excessiveRepeats) {
-      // Not empty? Add a space
-      if (content) content += ` `;
-
-      const line = plural('line', excessiveRepeats);
-      const has = plural('has', excessiveRepeats, 'have');
-
-      content += `${excessiveRepeats} log ${line} ${has} been excessively repeated.`;
-    }
-
-    return (
-      <Tooltip title={content} placement="right">
-        <Badge status="warning" />
-      </Tooltip>
-    );
-  }
-
-  const treeProps = {
+  const stateTreeProps = {
     showLine: true,
-    onSelect,
+    onSelect: onStateSelect,
     showIcon: true,
     blockNode: true,
     switcherIcon: <DownOutlined />,
@@ -479,12 +309,28 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             label: 'Logs',
             icon: <FileTextOutlined />,
             children: (
-              <Tree
-                {...treeProps}
-                onExpand={(keys) => setExpandedLogKeys(keys)}
-                expandedKeys={expandedLogKeys}
-                treeData={logNodes}
-              />
+              <div style={{ padding: '4px 0' }}>
+                {availableLogTypes.map(({ type, label, icon }) => (
+                  <div
+                    key={type}
+                    style={{
+                      padding: '6px 12px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                  >
+                    <Checkbox
+                      checked={logTypeFilter[type]}
+                      onChange={(e) => onLogTypeToggle(type, e.target.checked)}
+                    />
+                    <Space size={4}>
+                      {icon}
+                      <Typography.Text>{label}</Typography.Text>
+                    </Space>
+                  </div>
+                ))}
+              </div>
             ),
           },
           {
@@ -493,7 +339,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             icon: <SettingOutlined />,
             children: (
               <Tree
-                {...treeProps}
+                {...stateTreeProps}
                 onExpand={(keys) => setExpandedStateKeys(keys)}
                 expandedKeys={expandedStateKeys}
                 treeData={stateNodes}

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -54,7 +54,8 @@ import { isMergedLogFile } from '../../../utils/is-logfile';
 import { getEnvironmentWarnings } from '../../analytics/environment-analytics';
 import { getRootStateWarnings } from '../../analytics/root-state-analytics';
 import { getTraceWarnings } from '../../analytics/trace-analytics';
-import { hashTagColor, logColorMap } from '../log-table';
+import { hashTagColor } from '../../../utils/match-tag';
+import { logColorMap } from '../log-table';
 import { TraceProcessor } from '../../processor/trace';
 
 interface SidebarFileTreeProps {

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Badge,
   Segmented,
   Select,
@@ -666,12 +667,22 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             label: 'State',
             icon: <SettingOutlined />,
             children: (
-              <Tree
-                {...stateTreeProps}
-                onExpand={(keys) => setExpandedStateKeys(keys)}
-                expandedKeys={expandedStateKeys}
-                treeData={stateNodes}
-              />
+              <fieldset className="SidebarCheckboxGroup">
+                <legend className="SidebarCheckboxGroup-legend">
+                  <Typography.Text
+                    type="secondary"
+                    className="SidebarCheckboxGroup-title"
+                  >
+                    State & Settings
+                  </Typography.Text>
+                </legend>
+                <Tree
+                  {...stateTreeProps}
+                  onExpand={(keys) => setExpandedStateKeys(keys)}
+                  expandedKeys={expandedStateKeys}
+                  treeData={stateNodes}
+                />
+              </fieldset>
             ),
           },
           ...(processedLogFiles?.netlog?.length
@@ -690,6 +701,16 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                           Network Logs
                         </Typography.Text>
                       </legend>
+                      <Alert
+                        type="info"
+                        message={
+                          <Typography.Paragraph type="secondary">
+                            Net logs provide network-level captures showing HTTP
+                            requests, socket connections, and DNS lookups.
+                          </Typography.Paragraph>
+                        }
+                        className="SidebarPreamble"
+                      />
                       {processedLogFiles.netlog.map((file) => {
                         const isSelected =
                           isNetlogFileSelected && selectedKey === file.id;
@@ -723,6 +744,19 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                   icon: <DashboardOutlined />,
                   children: (
                     <>
+                      <Alert
+                        type="info"
+                        message={
+                          <Typography.Paragraph type="secondary">
+                            Performance profiles captured via Electron's{' '}
+                            <code>contentTracing</code> API. Inspect the entire
+                            trace with Google's Perfetto trace viewer, or
+                            analyze performance from a web perspective with
+                            Chrome DevTools.
+                          </Typography.Paragraph>
+                        }
+                        className="SidebarPreamble"
+                      />
                       <fieldset className="SidebarCheckboxGroup">
                         <legend className="SidebarCheckboxGroup-legend">
                           <Typography.Text

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -1,4 +1,15 @@
-import { Badge, Space, Tabs, theme, Tooltip, Tree, TreeDataNode } from 'antd';
+import {
+  Badge,
+  Segmented,
+  Select,
+  Space,
+  Tabs,
+  theme,
+  Tooltip,
+  Tree,
+  TreeDataNode,
+  Typography,
+} from 'antd';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
 import React, { Key, useCallback, useEffect, useMemo, useState } from 'react';
@@ -38,6 +49,7 @@ import { isMergedLogFile } from '../../../utils/is-logfile';
 import { getEnvironmentWarnings } from '../../analytics/environment-analytics';
 import { getRootStateWarnings } from '../../analytics/root-state-analytics';
 import { getTraceWarnings } from '../../analytics/trace-analytics';
+import { hashTagColor } from '../log-table';
 
 interface SidebarFileTreeProps {
   state: SleuthState;
@@ -89,7 +101,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                   ? token.colorWarning
                   : key === LogLevel.info
                     ? token.colorInfo
-                    : token.colorTextTertiary
+                    : token.colorSuccess
             }
           />
         ),
@@ -103,6 +115,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     Map<string, ProcessedLogFile | UnzippedFile>
   >(new Map());
   const [manualTab, setManualTab] = useState<string | null>(null);
+  const [tagSort, setTagSort] = useState<'freq' | 'az'>('freq');
 
   useEffect(() => {
     async function fetchTree() {
@@ -264,6 +277,36 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     }));
   }, [processedLogFiles]);
 
+  // Collect unique tags with counts across all processable files
+  const tagOptions = useMemo(() => {
+    if (!processedLogFiles) return [];
+    const tagCounts = new Map<string, number>();
+    for (const typeKey of LOG_TYPE_CHECKBOXES.map(({ key }) => key)) {
+      const files =
+        (processedLogFiles[typeKey as keyof typeof processedLogFiles] as
+          | ProcessedLogFile[]
+          | undefined) ?? [];
+      for (const f of files) {
+        for (const entry of f.logEntries ?? []) {
+          if (entry.tag?.name) {
+            tagCounts.set(
+              entry.tag.name,
+              (tagCounts.get(entry.tag.name) ?? 0) + 1,
+            );
+          }
+        }
+      }
+    }
+    const sorted = Array.from(tagCounts.entries()).sort((a, b) =>
+      tagSort === 'az' ? a[0].localeCompare(b[0]) : b[1] - a[1],
+    );
+    return sorted.map(([name, count]) => ({
+      label: name,
+      value: name,
+      count,
+    }));
+  }, [processedLogFiles, tagSort]);
+
   // Determine which log types have files present, and compute line counts
   const logTypeItems = useMemo(() => {
     if (!processedLogFiles) return [];
@@ -391,7 +434,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     ) {
       const warnings = props.state.stateFiles[
         'logfiles-shipping-manifest.json'
-      ].data.files.filter((f) => f.fileName.endsWith('.dmp'));
+      ].data.files.filter((f: any) => f.fileName.endsWith('.dmp'));
       return (
         <Tooltip
           title={`${warnings.length} DMP files found in log bundle. Check corresponding errors on Sentry.`}
@@ -418,7 +461,12 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     <div className={classNames('SidebarFileTree', { Open: isSidebarOpen })}>
       <Tabs
         activeKey={activeTab}
-        onChange={setManualTab}
+        onChange={(key) => {
+          setManualTab(key);
+          if (key === 'logs' && isStateFileSelected) {
+            props.state.selectLogFile(null, LogType.ALL);
+          }
+        }}
         size="small"
         items={[
           {
@@ -445,6 +493,141 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                   onShowAll={onLevelShowAll}
                   allShownWhen="all-true"
                 />
+                {tagOptions.length > 0 && (
+                  <fieldset
+                    style={{
+                      border: 'none',
+                      borderTop: '1px solid var(--ant-color-border)',
+                      margin: 0,
+                      padding: '4px 0 12px',
+                    }}
+                  >
+                    <legend
+                      style={{
+                        padding: '0 4px 0 0',
+                        margin: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                      }}
+                    >
+                      <Typography.Text
+                        type="secondary"
+                        style={{
+                          fontSize: 11,
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.5,
+                        }}
+                      >
+                        Tags
+                      </Typography.Text>
+                      <Segmented
+                        size="small"
+                        value={tagSort}
+                        onChange={(val) => setTagSort(val as 'freq' | 'az')}
+                        options={[
+                          { label: '#', value: 'freq' },
+                          { label: 'Az', value: 'az' },
+                        ]}
+                        style={{ fontSize: 10 }}
+                      />
+                    </legend>
+                    <Select
+                      mode="multiple"
+                      placeholder="Filter by tag..."
+                      options={tagOptions}
+                      value={props.state.selectedTags}
+                      onChange={(tags) => props.state.setSelectedTags(tags)}
+                      style={{
+                        width: '100%',
+                        fontFamily: 'Fira Code, monospace',
+                      }}
+                      size="small"
+                      allowClear
+                      optionRender={(option) => {
+                        const count = (option.data as { count?: number }).count;
+                        const countLabel =
+                          count !== undefined
+                            ? count >= 1000
+                              ? `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
+                              : String(count)
+                            : '';
+                        return (
+                          <span
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              fontFamily: 'Fira Code, monospace',
+                              color: hashTagColor(
+                                String(option.value ?? ''),
+                                props.state.prefersDarkColors,
+                              ),
+                            }}
+                          >
+                            <span
+                              style={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                minWidth: 0,
+                              }}
+                            >
+                              {option.label}
+                            </span>
+                            <span
+                              style={{
+                                opacity: 0.5,
+                                flexShrink: 0,
+                                marginLeft: 8,
+                              }}
+                            >
+                              {countLabel}
+                            </span>
+                          </span>
+                        );
+                      }}
+                      tagRender={({ label, value, closable, onClose }) => (
+                        <span
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 4,
+                            maxWidth: 160,
+                            padding: '0 4px',
+                            borderRadius: 4,
+                            border: '1px solid var(--ant-color-border)',
+                            marginInlineEnd: 4,
+                            fontSize: 12,
+                            fontFamily: 'Fira Code, monospace',
+                            color: hashTagColor(
+                              String(value ?? ''),
+                              props.state.prefersDarkColors,
+                            ),
+                          }}
+                        >
+                          <span
+                            style={{
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              minWidth: 0,
+                            }}
+                          >
+                            {label}
+                          </span>
+                          {closable && (
+                            <span
+                              onClick={onClose}
+                              style={{ cursor: 'pointer', marginLeft: 2 }}
+                            >
+                              ×
+                            </span>
+                          )}
+                        </span>
+                      )}
+                    />
+                  </fieldset>
+                )}
               </>
             ),
           },

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -507,8 +507,28 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
                         value={tagSort}
                         onChange={(val) => setTagSort(val as 'freq' | 'az')}
                         options={[
-                          { label: '#', value: 'freq' },
-                          { label: 'Az', value: 'az' },
+                          {
+                            label: (
+                              <Tooltip
+                                title="Sort by frequency"
+                                classNames={{ root: 'SidebarTooltip-sm' }}
+                              >
+                                #
+                              </Tooltip>
+                            ),
+                            value: 'freq',
+                          },
+                          {
+                            label: (
+                              <Tooltip
+                                title="Sort alphabetically"
+                                classNames={{ root: 'SidebarTooltip-sm' }}
+                              >
+                                Az
+                              </Tooltip>
+                            ),
+                            value: 'az',
+                          },
                         ]}
                         className="SidebarTags-sortToggle"
                       />

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -18,6 +18,7 @@ import {
   ProcessedLogFile,
   SelectableLogType,
   UnzippedFile,
+  LogTypeFilter,
 } from '../../../interfaces';
 import {
   ApartmentOutlined,
@@ -62,19 +63,19 @@ interface LogTypeCheckboxConfig {
 const LOG_TYPE_CHECKBOXES: LogTypeCheckboxConfig[] = [
   {
     type: LogType.BROWSER,
-    label: 'Browser Process',
+    label: 'Browser',
     icon: <DesktopOutlined />,
+  },
+  { type: LogType.WEBAPP, label: 'Webapp', icon: <CommentOutlined /> },
+  {
+    type: LogType.SERVICE_WORKER,
+    label: 'Service worker',
+    icon: <CloudOutlined />,
   },
   {
     type: LogType.EPIC_TRACES,
-    label: 'Epic Traces',
+    label: 'Epic traces',
     icon: <ExperimentOutlined />,
-  },
-  { type: LogType.WEBAPP, label: 'WebApp', icon: <CommentOutlined /> },
-  {
-    type: LogType.SERVICE_WORKER,
-    label: 'Service Worker',
-    icon: <CloudOutlined />,
   },
   { type: LogType.CHROMIUM, label: 'Chromium', icon: <ChromeOutlined /> },
   { type: LogType.INSTALLER, label: 'Installer', icon: <DownloadOutlined /> },
@@ -87,6 +88,9 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     Map<string, ProcessedLogFile | UnzippedFile>
   >(new Map());
   const [manualTab, setManualTab] = useState<string | null>(null);
+  const [hoveredType, setHoveredType] = useState<ProcessableLogType | null>(
+    null,
+  );
 
   useEffect(() => {
     async function fetchTree() {
@@ -129,6 +133,33 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
       props.state.setLogTypeFilter({ [logType]: checked });
 
       // Ensure the ALL merged view is selected
+      const { selectedLogFile } = props.state;
+      if (
+        !selectedLogFile ||
+        !isMergedLogFile(selectedLogFile) ||
+        selectedLogFile.logType !== LogType.ALL
+      ) {
+        props.state.selectLogFile(null, LogType.ALL);
+      }
+    },
+    [props.state],
+  );
+
+  const onLogTypeFocus = useCallback(
+    (logType: ProcessableLogType) => {
+      const { logTypeFilter } = props.state;
+      // If this type is already the only one enabled, re-enable all
+      const isAlreadyFocused = LOG_TYPE_CHECKBOXES.every(
+        ({ type }) => logTypeFilter[type] === (type === logType),
+      );
+      const filter = Object.fromEntries(
+        LOG_TYPE_CHECKBOXES.map(({ type }) => [
+          type,
+          isAlreadyFocused ? true : type === logType,
+        ]),
+      ) as Partial<LogTypeFilter>;
+      props.state.setLogTypeFilter(filter);
+
       const { selectedLogFile } = props.state;
       if (
         !selectedLogFile ||
@@ -310,26 +341,98 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             icon: <FileTextOutlined />,
             children: (
               <div style={{ padding: '4px 0' }}>
-                {availableLogTypes.map(({ type, label, icon }) => (
-                  <div
-                    key={type}
-                    style={{
-                      padding: '6px 12px',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                    }}
-                  >
-                    <Checkbox
-                      checked={logTypeFilter[type]}
-                      onChange={(e) => onLogTypeToggle(type, e.target.checked)}
-                    />
-                    <Space size={4}>
-                      {icon}
-                      <Typography.Text>{label}</Typography.Text>
-                    </Space>
-                  </div>
-                ))}
+                <Typography.Text
+                  type="secondary"
+                  style={{
+                    fontSize: 11,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    padding: '2px 4px 4px',
+                    display: 'block',
+                  }}
+                >
+                  Log Types
+                </Typography.Text>
+                {availableLogTypes.map(({ type, label, icon }) => {
+                  const files =
+                    (processedLogFiles?.[
+                      type as keyof typeof processedLogFiles
+                    ] as ProcessedLogFile[] | undefined) ?? [];
+                  const lineCount = files.reduce(
+                    (sum, f) => sum + (f.logEntries?.length ?? 0),
+                    0,
+                  );
+                  const isHovered = hoveredType === type;
+                  return (
+                    <div
+                      key={type}
+                      style={{
+                        padding: '1px 4px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        borderRadius: 4,
+                        cursor: 'pointer',
+                        background: isHovered
+                          ? 'var(--ant-color-fill-secondary)'
+                          : 'transparent',
+                        transition: 'background 0.15s ease',
+                      }}
+                      onMouseEnter={() => setHoveredType(type)}
+                      onMouseLeave={() => setHoveredType(null)}
+                      onClick={() => onLogTypeFocus(type)}
+                    >
+                      <Checkbox
+                        checked={logTypeFilter[type]}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          onLogTypeToggle(type, e.target.checked);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <Space size={4} style={{ flex: 1 }}>
+                        {icon}
+                        <Typography.Text style={{ fontSize: 14 }}>
+                          {label}
+                        </Typography.Text>
+                      </Space>
+                      <span
+                        style={{
+                          position: 'relative',
+                          minWidth: 32,
+                          textAlign: 'right',
+                        }}
+                      >
+                        <Typography.Text
+                          type="secondary"
+                          style={{
+                            fontSize: 12,
+                            opacity: isHovered ? 0 : 1,
+                            transition: 'opacity 0.15s ease',
+                          }}
+                        >
+                          {lineCount.toLocaleString()}
+                        </Typography.Text>
+                        <Typography.Text
+                          type="secondary"
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            textTransform: 'uppercase',
+                            letterSpacing: 0.5,
+                            position: 'absolute',
+                            right: 0,
+                            top: 0,
+                            opacity: isHovered ? 1 : 0,
+                            transition: 'opacity 0.15s ease',
+                          }}
+                        >
+                          only
+                        </Typography.Text>
+                      </span>
+                    </div>
+                  );
+                })}
               </div>
             ),
           },

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -1,18 +1,11 @@
-import {
-  Badge,
-  Checkbox,
-  Space,
-  Tabs,
-  Tooltip,
-  Tree,
-  TreeDataNode,
-  Typography,
-} from 'antd';
+import { Badge, Space, Tabs, theme, Tooltip, Tree, TreeDataNode } from 'antd';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
-import React, { Key, useCallback, useEffect, useState } from 'react';
+import React, { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { SleuthState } from '../../state/sleuth';
 import {
+  LevelFilter,
+  LogLevel,
   LogType,
   ProcessableLogType,
   ProcessedLogFile,
@@ -40,6 +33,7 @@ import {
   SettingOutlined,
   WarningFilled,
 } from '@ant-design/icons';
+import { CheckboxItem, SidebarCheckboxGroup } from './sidebar-checkbox-group';
 import { isMergedLogFile } from '../../../utils/is-logfile';
 import { getEnvironmentWarnings } from '../../analytics/environment-analytics';
 import { getRootStateWarnings } from '../../analytics/root-state-analytics';
@@ -54,43 +48,61 @@ interface SidebarNodeData {
   type: SelectableLogType;
 }
 
-interface LogTypeCheckboxConfig {
-  type: ProcessableLogType;
-  label: string;
-  icon: React.ReactNode;
-}
-
-const LOG_TYPE_CHECKBOXES: LogTypeCheckboxConfig[] = [
+const LOG_TYPE_CHECKBOXES: CheckboxItem[] = [
+  { key: LogType.BROWSER, label: 'browser', icon: <DesktopOutlined /> },
+  { key: LogType.WEBAPP, label: 'webapp', icon: <CommentOutlined /> },
   {
-    type: LogType.BROWSER,
-    label: 'browser',
-    icon: <DesktopOutlined />,
-  },
-  { type: LogType.WEBAPP, label: 'webapp', icon: <CommentOutlined /> },
-  {
-    type: LogType.SERVICE_WORKER,
+    key: LogType.SERVICE_WORKER,
     label: 'service worker',
     icon: <CloudOutlined />,
   },
   {
-    type: LogType.rx_epic,
+    key: LogType.rx_epic,
     label: 'epic traces',
     icon: <ExperimentOutlined />,
   },
-  { type: LogType.CHROMIUM, label: 'chromium', icon: <ChromeOutlined /> },
-  { type: LogType.INSTALLER, label: 'installer', icon: <DownloadOutlined /> },
+  { key: LogType.CHROMIUM, label: 'chromium', icon: <ChromeOutlined /> },
+  { key: LogType.INSTALLER, label: 'installer', icon: <DownloadOutlined /> },
+];
+
+const LOG_LEVEL_KEYS = [
+  { key: LogLevel.error, label: 'error' },
+  { key: LogLevel.warn, label: 'warning' },
+  { key: LogLevel.info, label: 'info' },
+  { key: LogLevel.debug, label: 'debug' },
 ];
 
 const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
+  const { token } = theme.useToken();
+
+  const LOG_LEVEL_CHECKBOXES: CheckboxItem[] = useMemo(
+    () =>
+      LOG_LEVEL_KEYS.map(({ key, label }) => ({
+        key,
+        label,
+        icon: (
+          <Badge
+            color={
+              key === LogLevel.error
+                ? token.colorError
+                : key === LogLevel.warn
+                  ? token.colorWarning
+                  : key === LogLevel.info
+                    ? token.colorInfo
+                    : token.colorTextTertiary
+            }
+          />
+        ),
+      })),
+    [token],
+  );
+
   const [stateNodes, setStateNodes] = useState<TreeDataNode[]>([]);
   const [expandedStateKeys, setExpandedStateKeys] = useState<Key[]>();
   const [files, setFiles] = useState<
     Map<string, ProcessedLogFile | UnzippedFile>
   >(new Map());
   const [manualTab, setManualTab] = useState<string | null>(null);
-  const [hoveredType, setHoveredType] = useState<ProcessableLogType | null>(
-    null,
-  );
 
   useEffect(() => {
     async function fetchTree() {
@@ -128,11 +140,10 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     [props.state, files],
   );
 
+  // --- Log type callbacks ---
   const onLogTypeToggle = useCallback(
-    (logType: ProcessableLogType, checked: boolean) => {
-      props.state.setLogTypeFilter({ [logType]: checked });
-
-      // Ensure the ALL merged view is selected
+    (key: string, checked: boolean) => {
+      props.state.setLogTypeFilter({ [key]: checked });
       const { selectedLogFile } = props.state;
       if (
         !selectedLogFile ||
@@ -145,24 +156,24 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     [props.state],
   );
 
-  const onShowAll = useCallback(() => {
+  const onLogTypeShowAll = useCallback(() => {
     const filter = Object.fromEntries(
-      LOG_TYPE_CHECKBOXES.map(({ type }) => [type, true]),
+      LOG_TYPE_CHECKBOXES.map(({ key }) => [key, true]),
     ) as Partial<LogTypeFilter>;
     props.state.setLogTypeFilter(filter);
   }, [props.state]);
 
   const onLogTypeFocus = useCallback(
-    (logType: ProcessableLogType) => {
+    (focusKey: string) => {
       const { logTypeFilter } = props.state;
-      // If this type is already the only one enabled, re-enable all
       const isAlreadyFocused = LOG_TYPE_CHECKBOXES.every(
-        ({ type }) => logTypeFilter[type] === (type === logType),
+        ({ key }) =>
+          logTypeFilter[key as ProcessableLogType] === (key === focusKey),
       );
       const filter = Object.fromEntries(
-        LOG_TYPE_CHECKBOXES.map(({ type }) => [
-          type,
-          isAlreadyFocused ? true : type === logType,
+        LOG_TYPE_CHECKBOXES.map(({ key }) => [
+          key,
+          isAlreadyFocused ? true : key === focusKey,
         ]),
       ) as Partial<LogTypeFilter>;
       props.state.setLogTypeFilter(filter);
@@ -175,6 +186,41 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
       ) {
         props.state.selectLogFile(null, LogType.ALL);
       }
+    },
+    [props.state],
+  );
+
+  // --- Log level callbacks ---
+  const onLevelToggle = useCallback(
+    (key: string, checked: boolean) => {
+      props.state.setFilterLogLevels({ [key]: checked });
+    },
+    [props.state],
+  );
+
+  const onLevelShowAll = useCallback(() => {
+    props.state.setFilterLogLevels({
+      debug: true,
+      info: true,
+      warn: true,
+      error: true,
+    });
+  }, [props.state]);
+
+  const onLevelFocus = useCallback(
+    (focusKey: string) => {
+      const { levelFilter } = props.state;
+      const isAlreadyFocused = LOG_LEVEL_KEYS.every(
+        ({ key }) => levelFilter[key as LogLevel] === (key === focusKey),
+      );
+      props.state.setFilterLogLevels(
+        Object.fromEntries(
+          LOG_LEVEL_KEYS.map(({ key }) => [
+            key,
+            isAlreadyFocused ? true : key === focusKey,
+          ]),
+        ) as Partial<LevelFilter>,
+      );
     },
     [props.state],
   );
@@ -197,12 +243,45 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
   const derivedTab = isStateFileSelected ? 'state' : 'logs';
   const activeTab = manualTab ?? derivedTab;
 
-  // Determine which log types have files present
-  const availableLogTypes = LOG_TYPE_CHECKBOXES.filter(({ type }) => {
-    if (!processedLogFiles) return false;
-    const key = type as keyof typeof processedLogFiles;
-    return processedLogFiles[key]?.length > 0;
-  });
+  // Compute log level line counts across all processable files
+  const logLevelItems = useMemo(() => {
+    if (!processedLogFiles) return LOG_LEVEL_CHECKBOXES as CheckboxItem[];
+    const totals: Record<string, number> = {};
+    for (const typeKey of LOG_TYPE_CHECKBOXES.map(({ key }) => key)) {
+      const files =
+        (processedLogFiles[typeKey as keyof typeof processedLogFiles] as
+          | ProcessedLogFile[]
+          | undefined) ?? [];
+      for (const f of files) {
+        for (const [level, count] of Object.entries(f.levelCounts ?? {})) {
+          totals[level] = (totals[level] ?? 0) + count;
+        }
+      }
+    }
+    return LOG_LEVEL_CHECKBOXES.map((item) => ({
+      ...item,
+      count: totals[item.key] ?? 0,
+    }));
+  }, [processedLogFiles]);
+
+  // Determine which log types have files present, and compute line counts
+  const logTypeItems = useMemo(() => {
+    if (!processedLogFiles) return [];
+    return LOG_TYPE_CHECKBOXES.filter(({ key }) => {
+      const pKey = key as keyof typeof processedLogFiles;
+      return processedLogFiles[pKey]?.length > 0;
+    }).map((item) => {
+      const typeFiles =
+        (processedLogFiles[item.key as keyof typeof processedLogFiles] as
+          | ProcessedLogFile[]
+          | undefined) ?? [];
+      const count = typeFiles.reduce(
+        (sum: number, f: ProcessedLogFile) => sum + (f.logEntries?.length ?? 0),
+        0,
+      );
+      return { ...item, count };
+    });
+  }, [processedLogFiles]);
 
   function getNode(
     id: string,
@@ -347,128 +426,26 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
             label: 'Logs',
             icon: <FileTextOutlined />,
             children: (
-              <div style={{ padding: '4px 0' }}>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'baseline',
-                    justifyContent: 'space-between',
-                    padding: '2px 4px 4px',
-                  }}
-                >
-                  <Typography.Text
-                    type="secondary"
-                    style={{
-                      fontSize: 11,
-                      textTransform: 'uppercase',
-                      letterSpacing: 0.5,
-                    }}
-                  >
-                    Log Types
-                  </Typography.Text>
-                  {!availableLogTypes.every(
-                    ({ type }) => logTypeFilter[type],
-                  ) && (
-                    <Typography.Text
-                      strong
-                      style={{
-                        fontSize: 11,
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.5,
-                        cursor: 'pointer',
-                      }}
-                      onClick={onShowAll}
-                    >
-                      Show all
-                    </Typography.Text>
-                  )}
-                </div>
-                {availableLogTypes.map(({ type, label, icon }) => {
-                  const files =
-                    (processedLogFiles?.[
-                      type as keyof typeof processedLogFiles
-                    ] as ProcessedLogFile[] | undefined) ?? [];
-                  const lineCount = files.reduce(
-                    (sum, f) => sum + (f.logEntries?.length ?? 0),
-                    0,
-                  );
-                  const isHovered = hoveredType === type;
-                  return (
-                    <div
-                      key={type}
-                      style={{
-                        padding: '1px 4px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 8,
-                        borderRadius: 4,
-                        cursor: 'pointer',
-                        background: isHovered
-                          ? 'var(--ant-color-fill-secondary)'
-                          : 'transparent',
-                        transition: 'background 0.15s ease',
-                      }}
-                      onMouseEnter={() => setHoveredType(type)}
-                      onMouseLeave={() => setHoveredType(null)}
-                      onClick={() => onLogTypeFocus(type)}
-                    >
-                      <Checkbox
-                        checked={logTypeFilter[type]}
-                        onChange={(e) => {
-                          e.stopPropagation();
-                          onLogTypeToggle(type, e.target.checked);
-                        }}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                      <Space size={4} style={{ flex: 1 }}>
-                        {icon}
-                        <Typography.Text style={{ fontSize: 14 }}>
-                          {label}
-                        </Typography.Text>
-                      </Space>
-                      <span
-                        style={{
-                          position: 'relative',
-                          minWidth: 36,
-                          textAlign: 'right',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'flex-end',
-                        }}
-                      >
-                        <Typography.Text
-                          type="secondary"
-                          style={{
-                            fontSize: 12,
-                            opacity: isHovered ? 0 : 1,
-                            transition: 'opacity 0.15s ease',
-                          }}
-                        >
-                          {lineCount.toLocaleString()}
-                        </Typography.Text>
-                        <Typography.Text
-                          strong
-                          style={{
-                            fontSize: 11,
-                            textTransform: 'uppercase',
-                            letterSpacing: 0.5,
-                            position: 'absolute',
-                            inset: 0,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'flex-end',
-                            opacity: isHovered ? 1 : 0,
-                            transition: 'opacity 0.15s ease',
-                            color: 'var(--ant-color-primary)',
-                          }}
-                        >
-                          ONLY
-                        </Typography.Text>
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
+              <>
+                <SidebarCheckboxGroup
+                  title="Log Types"
+                  items={logTypeItems}
+                  filter={logTypeFilter}
+                  onToggle={onLogTypeToggle}
+                  onFocus={onLogTypeFocus}
+                  onShowAll={onLogTypeShowAll}
+                  allShownWhen="all-true"
+                />
+                <SidebarCheckboxGroup
+                  title="Log Levels"
+                  items={logLevelItems}
+                  filter={props.state.levelFilter}
+                  onToggle={onLevelToggle}
+                  onFocus={onLevelFocus}
+                  onShowAll={onLevelShowAll}
+                  allShownWhen="all-true"
+                />
+              </>
             ),
           },
           {

--- a/src/renderer/processor/trace.ts
+++ b/src/renderer/processor/trace.ts
@@ -100,9 +100,10 @@ export class TraceProcessor {
     }
 
     rendererThreadsEvents.forEach((thread) => {
-      const title = getProcessLabel(labelEvents, thread.pid);
+      const label = getProcessLabel(labelEvents, thread.pid);
+      const title = label || `Renderer (PID ${thread.pid})`;
       d(`Discovered renderer thread via thread event: ${title}`);
-      const isClient = title.startsWith('Slack |');
+      const isClient = label.startsWith('Slack |');
       const processId = thread.pid;
       if (!discovered[processId]) {
         discovered[processId] = {

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -119,6 +119,7 @@ export class SleuthState {
   @observable public prefersDarkColors = false;
   // ** Profiler **
   @observable public traceThreads?: Array<TraceThreadDescription>;
+  @observable public selectedTracePid?: number;
 
   @observable
   public selectedTraceViewer: TRACE_VIEWER;
@@ -343,6 +344,7 @@ export class SleuthState {
     this.isDetailsVisible = false;
     this.dateRange = { from: null, to: null };
     this.traceThreads = undefined;
+    this.selectedTracePid = undefined;
     this.stateFiles = {};
 
     if (goBackToHome) {
@@ -424,6 +426,7 @@ export class SleuthState {
     d(`Opening trace viewer: ${viewerType}`);
 
     this.selectedTraceViewer = viewerType;
+    this.selectedTracePid = undefined;
 
     if (!this.processedLogFiles?.trace?.length) {
       return;
@@ -433,6 +436,11 @@ export class SleuthState {
     if (firstTraceFile) {
       this.selectLogFile(firstTraceFile);
     }
+  }
+
+  @action
+  public setSelectedTracePid(pid: number | undefined) {
+    this.selectedTracePid = pid;
   }
 
   /**

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -17,6 +17,7 @@ import { getFileName } from '../../utils/get-file-name';
 import {
   LevelFilter,
   LogEntry,
+  LogTypeFilter,
   MergedLogFile,
   ProcessedLogFile,
   DateRange,
@@ -81,6 +82,15 @@ export class SleuthState {
     error: false,
     info: false,
     warn: false,
+  };
+  @observable public logTypeFilter: LogTypeFilter = {
+    browser: true,
+    epic_traces: true,
+    webapp: true,
+    service_worker: true,
+    chromium: true,
+    installer: true,
+    mobile: true,
   };
   @observable public searchIndex = 0;
   @observable public searchList: number[] = [];
@@ -318,6 +328,13 @@ export class SleuthState {
     this.levelFilter.error = false;
     this.levelFilter.info = false;
     this.levelFilter.warn = false;
+    this.logTypeFilter.browser = true;
+    this.logTypeFilter.epic_traces = true;
+    this.logTypeFilter.webapp = true;
+    this.logTypeFilter.service_worker = true;
+    this.logTypeFilter.chromium = true;
+    this.logTypeFilter.installer = true;
+    this.logTypeFilter.mobile = true;
     this.searchIndex = 0;
     this.showOnlySearchResults = undefined;
     this.isSpotlightOpen = false;
@@ -369,6 +386,11 @@ export class SleuthState {
   @action
   public setFilterLogLevels(levels: Partial<LevelFilter>) {
     this.levelFilter = { ...this.levelFilter, ...levels };
+  }
+
+  @action
+  public setLogTypeFilter(types: Partial<LogTypeFilter>) {
+    this.logTypeFilter = { ...this.logTypeFilter, ...types };
   }
 
   /**

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -92,6 +92,7 @@ export class SleuthState {
     installer: true,
     mobile: true,
   };
+  @observable public selectedTags: string[] = [];
   @observable public searchIndex = 0;
   @observable public searchList: number[] = [];
   @observable public search = '';
@@ -335,6 +336,7 @@ export class SleuthState {
     this.logTypeFilter.chromium = true;
     this.logTypeFilter.installer = true;
     this.logTypeFilter.mobile = true;
+    this.selectedTags = [];
     this.searchIndex = 0;
     this.showOnlySearchResults = undefined;
     this.isSpotlightOpen = false;
@@ -391,6 +393,11 @@ export class SleuthState {
   @action
   public setLogTypeFilter(types: Partial<LogTypeFilter>) {
     this.logTypeFilter = { ...this.logTypeFilter, ...types };
+  }
+
+  @action
+  public setSelectedTags(tags: string[]) {
+    this.selectedTags = tags;
   }
 
   /**

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -34,6 +34,7 @@ import {
   Suggestion,
   SelectableLogType,
   TRACE_VIEWER,
+  LOG_TYPES_TO_PROCESS,
 } from '../../interfaces';
 import {
   getInitialTimeViewRange,
@@ -49,6 +50,10 @@ import { StateTableState } from '../components/state-table';
 import { Editor, EDITORS } from '../components/preferences/preferences-utils';
 
 const d = debug('sleuth:state');
+
+const DEFAULT_LOG_TYPE_FILTER: LogTypeFilter = Object.fromEntries(
+  LOG_TYPES_TO_PROCESS.map((t) => [t, true]),
+) as LogTypeFilter;
 
 export class SleuthState {
   // ** Log file selection **
@@ -84,13 +89,7 @@ export class SleuthState {
     warn: true,
   };
   @observable public logTypeFilter: LogTypeFilter = {
-    browser: true,
-    rx_epic: true,
-    webapp: true,
-    webapp_sw: true,
-    chromium: true,
-    installer: true,
-    mobile: true,
+    ...DEFAULT_LOG_TYPE_FILTER,
   };
   @observable public selectedTags: string[] = [];
   @observable public searchIndex = 0;
@@ -330,13 +329,7 @@ export class SleuthState {
     this.levelFilter.error = true;
     this.levelFilter.info = true;
     this.levelFilter.warn = true;
-    this.logTypeFilter.browser = true;
-    this.logTypeFilter.rx_epic = true;
-    this.logTypeFilter.webapp = true;
-    this.logTypeFilter.webapp_sw = true;
-    this.logTypeFilter.chromium = true;
-    this.logTypeFilter.installer = true;
-    this.logTypeFilter.mobile = true;
+    this.logTypeFilter = { ...DEFAULT_LOG_TYPE_FILTER };
     this.selectedTags = [];
     this.searchIndex = 0;
     this.showOnlySearchResults = undefined;
@@ -436,6 +429,11 @@ export class SleuthState {
     if (firstTraceFile) {
       this.selectLogFile(firstTraceFile);
     }
+  }
+
+  @action
+  public setTraceThreads(threads: TraceThreadDescription[] | undefined) {
+    this.traceThreads = threads;
   }
 
   @action

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -78,10 +78,10 @@ export class SleuthState {
 
   // ** Search and Filter **
   @observable public levelFilter: LevelFilter = {
-    debug: false,
-    error: false,
-    info: false,
-    warn: false,
+    debug: true,
+    error: true,
+    info: true,
+    warn: true,
   };
   @observable public logTypeFilter: LogTypeFilter = {
     browser: true,
@@ -324,10 +324,10 @@ export class SleuthState {
     this.selectedIndex = undefined;
     this.selectedLogFile = undefined;
     this.bookmarks = [];
-    this.levelFilter.debug = false;
-    this.levelFilter.error = false;
-    this.levelFilter.info = false;
-    this.levelFilter.warn = false;
+    this.levelFilter.debug = true;
+    this.levelFilter.error = true;
+    this.levelFilter.info = true;
+    this.levelFilter.warn = true;
     this.logTypeFilter.browser = true;
     this.logTypeFilter.rx_epic = true;
     this.logTypeFilter.webapp = true;

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -85,9 +85,9 @@ export class SleuthState {
   };
   @observable public logTypeFilter: LogTypeFilter = {
     browser: true,
-    epic_traces: true,
+    rx_epic: true,
     webapp: true,
-    service_worker: true,
+    webapp_sw: true,
     chromium: true,
     installer: true,
     mobile: true,
@@ -329,9 +329,9 @@ export class SleuthState {
     this.levelFilter.info = false;
     this.levelFilter.warn = false;
     this.logTypeFilter.browser = true;
-    this.logTypeFilter.epic_traces = true;
+    this.logTypeFilter.rx_epic = true;
     this.logTypeFilter.webapp = true;
-    this.logTypeFilter.service_worker = true;
+    this.logTypeFilter.webapp_sw = true;
     this.logTypeFilter.chromium = true;
     this.logTypeFilter.installer = true;
     this.logTypeFilter.mobile = true;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -214,3 +214,9 @@
   cursor: pointer;
   margin-left: 2px;
 }
+
+.SidebarTooltip-sm .ant-tooltip-inner {
+  font-size: var(--ant-font-size-sm);
+  min-height: auto;
+  padding: 2px var(--ant-padding-xs);
+}

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -65,6 +65,17 @@
   }
 }
 
+/* Sidebar preamble alert */
+.SidebarPreamble {
+  margin: var(--ant-padding-xs) 0;
+}
+
+.SidebarPreamble .ant-typography {
+  margin-bottom: 0;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
 /* SidebarCheckboxGroup */
 .SidebarCheckboxGroup {
   border: none;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -64,3 +64,153 @@
     background: transparent;
   }
 }
+
+/* SidebarCheckboxGroup */
+.SidebarCheckboxGroup {
+  border: none;
+  border-top: var(--ant-line-width) solid var(--ant-color-border);
+  margin: 0;
+  padding: var(--ant-padding-xxs) 0 var(--ant-padding-sm);
+}
+
+.SidebarCheckboxGroup-legend {
+  display: flex;
+  align-items: baseline;
+  gap: var(--ant-padding-xs);
+  padding: 0 var(--ant-padding-xxs) 0 0;
+  margin: 0;
+}
+
+.SidebarCheckboxGroup-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.SidebarCheckboxGroup-showAll {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+}
+
+.SidebarCheckboxGroup-row {
+  padding: 1px var(--ant-padding-xxs);
+  display: flex;
+  align-items: center;
+  gap: var(--ant-padding-xs);
+  border-radius: var(--ant-border-radius-sm);
+  cursor: pointer;
+  background: transparent;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--ant-color-fill-secondary);
+  }
+}
+
+.SidebarCheckboxGroup-label {
+  font-size: var(--ant-font-size);
+}
+
+.SidebarCheckboxGroup-countWrap {
+  position: relative;
+  min-width: 36px;
+  text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.SidebarCheckboxGroup-count {
+  font-size: var(--ant-font-size);
+  transition: opacity 0.15s ease;
+}
+
+.SidebarCheckboxGroup-only {
+  font-size: var(--ant-font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  transition: opacity 0.15s ease;
+  color: var(--ant-color-primary);
+}
+
+/* Sidebar Tags section */
+.SidebarTags {
+  border: none;
+  border-top: var(--ant-line-width) solid var(--ant-color-border);
+  margin: 0;
+  padding: var(--ant-padding-xxs) 0 var(--ant-padding-sm);
+}
+
+.SidebarTags-legend {
+  padding: 0 var(--ant-padding-xxs) 0 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--ant-padding-xs);
+}
+
+.SidebarTags-sortToggle {
+  font-size: 10px;
+}
+
+.SidebarTags-select {
+  width: 100%;
+  font-family:
+    Fira Code,
+    monospace;
+}
+
+.SidebarTags-option {
+  display: flex;
+  justify-content: space-between;
+  font-family:
+    Fira Code,
+    monospace;
+}
+
+.SidebarTags-optionLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.SidebarTags-optionCount {
+  opacity: 0.5;
+  flex-shrink: 0;
+  margin-left: var(--ant-margin-xs);
+}
+
+.SidebarTags-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ant-margin-xxs);
+  max-width: 160px;
+  padding: 0 var(--ant-padding-xxs);
+  border-radius: var(--ant-border-radius-sm);
+  border: var(--ant-line-width) solid var(--ant-color-border);
+  margin-inline-end: var(--ant-margin-xxs);
+  font-size: var(--ant-font-size-sm);
+  font-family:
+    Fira Code,
+    monospace;
+}
+
+.SidebarTags-tagLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.SidebarTags-tagClose {
+  cursor: pointer;
+  margin-left: 2px;
+}

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -107,6 +107,10 @@
   &:hover {
     background: var(--ant-color-fill-secondary);
   }
+
+  &.selected {
+    background: var(--ant-color-primary-bg);
+  }
 }
 
 .SidebarCheckboxGroup-label {

--- a/src/utils/get-file-types.ts
+++ b/src/utils/get-file-types.ts
@@ -18,9 +18,9 @@ const d = debug('sleuth:file-types');
 export function getTypesForFiles(logFiles: UnzippedFiles): SortedUnzippedFiles {
   const result: SortedUnzippedFiles = {
     browser: [],
-    epic_traces: [],
+    rx_epic: [],
     webapp: [],
-    service_worker: [],
+    webapp_sw: [],
     state: [],
     installer: [],
     netlog: [],
@@ -58,7 +58,7 @@ export function getTypeForFile(
   if (fileName.endsWith('.trace')) {
     return LogType.TRACE;
   } else if (fileName === 'browser-epics-trace.log') {
-    return LogType.EPIC_TRACES;
+    return LogType.rx_epic;
   } else if (
     fileName.startsWith('browser') ||
     fileName === 'epics-browser.log'

--- a/src/utils/get-file-types.ts
+++ b/src/utils/get-file-types.ts
@@ -18,7 +18,9 @@ const d = debug('sleuth:file-types');
 export function getTypesForFiles(logFiles: UnzippedFiles): SortedUnzippedFiles {
   const result: SortedUnzippedFiles = {
     browser: [],
+    epic_traces: [],
     webapp: [],
+    service_worker: [],
     state: [],
     installer: [],
     netlog: [],
@@ -55,11 +57,15 @@ export function getTypeForFile(
 
   if (fileName.endsWith('.trace')) {
     return LogType.TRACE;
+  } else if (fileName === 'browser-epics-trace.log') {
+    return LogType.EPIC_TRACES;
   } else if (
     fileName.startsWith('browser') ||
     fileName === 'epics-browser.log'
   ) {
     return LogType.BROWSER;
+  } else if (fileName === 'webapp-service-worker-console.log') {
+    return LogType.SERVICE_WORKER;
   } else if (
     fileName.startsWith('webapp') ||
     fileName.startsWith('app.slack') ||

--- a/src/utils/get-file-types.ts
+++ b/src/utils/get-file-types.ts
@@ -58,7 +58,7 @@ export function getTypeForFile(
   if (fileName.endsWith('.trace')) {
     return LogType.TRACE;
   } else if (fileName === 'browser-epics-trace.log') {
-    return LogType.rx_epic;
+    return LogType.RX_EPIC;
   } else if (
     fileName.startsWith('browser') ||
     fileName === 'epics-browser.log'

--- a/src/utils/match-tag.ts
+++ b/src/utils/match-tag.ts
@@ -18,3 +18,33 @@ export function matchTag(msg: string): RegExpExecArray | null {
     BROWSER_EPIC_TAG_PREFIX.exec(msg)
   );
 }
+
+const tagColorCache = new Map<string, string>();
+
+/**
+ * Maps a tag string to an HSL color hex code, varying by dark/light theme.
+ */
+export function hashTagColor(tag: string, dark: boolean): string {
+  const key = `${dark ? 'd' : 'l'}:${tag}`;
+  const cached = tagColorCache.get(key);
+  if (cached) return cached;
+
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++) {
+    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = ((hash % 360) + 360) % 360;
+  // Yellow-green (40–160) needs lower lightness for contrast on white backgrounds
+  // Blue-purple (220–310) needs higher lightness for contrast on dark backgrounds
+  const l = dark
+    ? h >= 220 && h < 310
+      ? 78
+      : 65
+    : h >= 40 && h < 160
+      ? 32
+      : 45;
+  const s = dark && h >= 220 && h < 310 ? 95 : 80;
+  const color = `hsl(${h}, ${s}%, ${l}%)`;
+  tagColorCache.set(key, color);
+  return color;
+}

--- a/src/utils/match-tag.ts
+++ b/src/utils/match-tag.ts
@@ -1,0 +1,20 @@
+/**
+ * Something like `[HUDDLES]` in webapp logs
+ */
+const WEBAPP_TAG_RGX = /^\s*\[([A-Za-z][A-Za-z0-9_ -]+)\]/;
+/**
+ * Something like `Store:` in desktop logs
+ */
+const BROWSER_PREFIX_RGX = /^\s*([A-Za-z][A-Za-z0-9_-]*(?:\s*\[[^\]]+\])?):/;
+/**
+ * Something like `Tag = fooBarEpic;` for rxjs-spy debug logs
+ */
+const BROWSER_EPIC_TAG_PREFIX = /^\s*Tag = ([A-Za-z][A-Za-z0-9_]*);/;
+
+export function matchTag(msg: string): RegExpExecArray | null {
+  return (
+    WEBAPP_TAG_RGX.exec(msg) ||
+    BROWSER_PREFIX_RGX.exec(msg) ||
+    BROWSER_EPIC_TAG_PREFIX.exec(msg)
+  );
+}

--- a/test/main/read-file.test.ts
+++ b/test/main/read-file.test.ts
@@ -114,6 +114,36 @@ describe('makeLogEntry', () => {
       timestamp: '1',
     });
   });
+
+  it('should populate tag for browser-style prefix', () => {
+    const result = makeLogEntry(
+      { message: 'Store: UPDATE_SETTINGS', timestamp: '1', level: 'info' },
+      'browser',
+      1,
+      'test-file',
+    );
+    expect(result.tag).toEqual({ name: 'Store', offset: 6 });
+  });
+
+  it('should populate tag for webapp-style [TAG]', () => {
+    const result = makeLogEntry(
+      { message: '[HUDDLES] joined call', timestamp: '1', level: 'info' },
+      'webapp',
+      1,
+      'test-file',
+    );
+    expect(result.tag).toEqual({ name: 'HUDDLES', offset: 9 });
+  });
+
+  it('should leave tag undefined for plain messages', () => {
+    const result = makeLogEntry(
+      { message: 'plain message', timestamp: '1', level: 'info' },
+      'browser',
+      1,
+      'test-file',
+    );
+    expect(result.tag).toBeUndefined();
+  });
 });
 
 describe('matchLineWebApp (additional)', () => {

--- a/test/renderer/components/devtools-view.test.tsx
+++ b/test/renderer/components/devtools-view.test.tsx
@@ -1,40 +1,15 @@
 import React from 'react';
 import { DevtoolsView } from '../../../src/renderer/components/devtools-view';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../../../src/renderer/processor/trace');
 
 describe('DevtoolsView', () => {
-  it('renders a table containing a list of trace threads', () => {
+  it('shows empty state when no trace PID is selected', () => {
     render(
       <DevtoolsView
-        state={
-          {
-            traceThreads: [
-              {
-                type: 'browser',
-                processId: 91908,
-                title: 'Main process',
-                pid: 91908,
-                tid: 259,
-                ts: 9007199254740991,
-                isClient: false,
-              },
-              {
-                type: 'renderer',
-                processId: 91918,
-                data: {
-                  frame: '',
-                  url: 'https://slack.com/unknown?name=',
-                  processId: 91918,
-                },
-                title: 'Renderer process',
-                isClient: false,
-              },
-            ],
-          } as any
-        }
+        state={{ selectedTracePid: undefined } as any}
         file={
           {
             fileName:
@@ -45,28 +20,15 @@ describe('DevtoolsView', () => {
       />,
     );
 
-    const tables = screen.getAllByRole('table');
-    expect(tables).toHaveLength(2);
+    expect(
+      screen.getByText('Select a process from the sidebar to view its trace'),
+    ).toBeInTheDocument();
   });
 
-  it('opens an iframe of the devtools frontend', () => {
+  it('renders an iframe when a trace PID is selected', () => {
     render(
       <DevtoolsView
-        state={
-          {
-            traceThreads: [
-              {
-                type: 'browser',
-                processId: 91908,
-                title: 'Main process',
-                pid: 91908,
-                tid: 259,
-                ts: 9007199254740991,
-                isClient: false,
-              },
-            ],
-          } as any
-        }
+        state={{ selectedTracePid: 91908 } as any}
         file={
           {
             fileName:
@@ -76,10 +38,6 @@ describe('DevtoolsView', () => {
         }
       />,
     );
-
-    const row = screen.getByRole('row', { name: /Main process/ });
-    const btn = within(row).getByRole('button');
-    fireEvent.click(btn);
 
     const iframe = screen.getByTitle('DevTools embed');
     expect(iframe).toBeInTheDocument();

--- a/test/renderer/components/sidebar.test.tsx
+++ b/test/renderer/components/sidebar.test.tsx
@@ -88,21 +88,22 @@ describe('Sidebar', () => {
           chromium: [fakeFile2],
         },
         logTypeFilter: defaultLogTypeFilter,
+        levelFilter: { debug: true, info: true, warn: true, error: true },
         bookmarks: [],
       };
 
       render(<Sidebar state={state as SleuthState} />);
 
-      const chromium = await screen.findByText('Chromium');
+      const chromium = await screen.findByText('chromium');
       expect(chromium).toBeInTheDocument();
 
-      const webapp = await screen.findByText('WebApp');
+      const webapp = await screen.findByText('webapp');
       expect(webapp).toBeInTheDocument();
 
-      const browser = await screen.findByText('Browser Process');
+      const browser = await screen.findByText('browser');
       expect(browser).toBeInTheDocument();
 
-      const installer = screen.queryByText('Installer');
+      const installer = screen.queryByText('installer');
       expect(installer).not.toBeInTheDocument();
     });
 
@@ -121,15 +122,16 @@ describe('Sidebar', () => {
           chromium: [],
         },
         logTypeFilter: defaultLogTypeFilter,
+        levelFilter: { debug: true, info: true, warn: true, error: true },
         bookmarks: [],
       };
 
       render(<Sidebar state={state as SleuthState} />);
 
-      const browser = screen.queryByText('Browser Process');
+      const browser = screen.queryByText('browser');
       expect(browser).not.toBeInTheDocument();
 
-      const webapp = screen.queryByText('WebApp');
+      const webapp = screen.queryByText('webapp');
       expect(webapp).not.toBeInTheDocument();
     });
 
@@ -148,6 +150,7 @@ describe('Sidebar', () => {
           chromium: [],
         },
         logTypeFilter: defaultLogTypeFilter,
+        levelFilter: { debug: true, info: true, warn: true, error: true },
         bookmarks: [],
         isSidebarOpen: false,
       };
@@ -183,15 +186,16 @@ describe('Sidebar', () => {
           chromium: [fakeFile2],
         },
         logTypeFilter: defaultLogTypeFilter,
+        levelFilter: { debug: true, info: true, warn: true, error: true },
         bookmarks: [],
       };
 
       render(<Sidebar state={state as SleuthState} />);
 
-      expect(await screen.findByText('Browser Process')).toBeInTheDocument();
-      expect(await screen.findByText('WebApp')).toBeInTheDocument();
-      expect(await screen.findByText('Chromium')).toBeInTheDocument();
-      expect(await screen.findByText('Installer')).toBeInTheDocument();
+      expect(await screen.findByText('browser')).toBeInTheDocument();
+      expect(await screen.findByText('webapp')).toBeInTheDocument();
+      expect(await screen.findByText('chromium')).toBeInTheDocument();
+      expect(await screen.findByText('installer')).toBeInTheDocument();
     });
   });
 });

--- a/test/renderer/components/sidebar.test.tsx
+++ b/test/renderer/components/sidebar.test.tsx
@@ -31,6 +31,16 @@ vi.mock(
   },
 );
 
+const defaultLogTypeFilter = {
+  browser: true,
+  epic_traces: true,
+  webapp: true,
+  service_worker: true,
+  chromium: true,
+  installer: true,
+  mobile: true,
+};
+
 const fakeFile1: ProcessedLogFile = {
   repeatedCounts: {},
   id: '123',
@@ -63,11 +73,13 @@ const fakeFile3: ProcessedLogFile = {
 
 describe('Sidebar', () => {
   describe('File Tree', () => {
-    it('hides the sidebar log types that dont have files in them', async () => {
+    it('shows checkboxes only for log types that have files', async () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
+          epic_traces: [],
           webapp: [fakeFile3],
+          service_worker: [],
           state: [],
           netlog: [],
           installer: [],
@@ -75,6 +87,7 @@ describe('Sidebar', () => {
           mobile: [],
           chromium: [fakeFile2],
         },
+        logTypeFilter: defaultLogTypeFilter,
         bookmarks: [],
       };
 
@@ -89,53 +102,44 @@ describe('Sidebar', () => {
       const browser = await screen.findByText('Browser Process');
       expect(browser).toBeInTheDocument();
 
-      const all = await screen.findByText('All Desktop Logs');
-      expect(all).toBeInTheDocument();
-
-      const mobile = screen.queryByText('Mobile');
-      expect(mobile).not.toBeInTheDocument();
-
       const installer = screen.queryByText('Installer');
       expect(installer).not.toBeInTheDocument();
     });
 
-    it('does not show "All Desktop Logs" if none exist', async () => {
+    it('shows no log type checkboxes when no processable files exist', async () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [],
+          epic_traces: [],
           webapp: [],
+          service_worker: [],
           state: [],
           netlog: [],
           installer: [],
           trace: [],
-          mobile: [
-            {
-              repeatedCounts: {},
-              id: '12345',
-              logEntries: [],
-              logFile: fakeUnzippedFile,
-              logType: LogType.MOBILE,
-              type: 'ProcessedLogFile',
-              levelCounts: {},
-            },
-          ],
+          mobile: [],
           chromium: [],
         },
+        logTypeFilter: defaultLogTypeFilter,
         bookmarks: [],
       };
 
       render(<Sidebar state={state as SleuthState} />);
 
-      await expect(
-        screen.findByText('All Desktop Logs', {}, { timeout: 500 }),
-      ).rejects.toThrow();
+      const browser = screen.queryByText('Browser Process');
+      expect(browser).not.toBeInTheDocument();
+
+      const webapp = screen.queryByText('WebApp');
+      expect(webapp).not.toBeInTheDocument();
     });
 
     it('is hidden if `isSidebarOpen` is false', async () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
+          epic_traces: [],
           webapp: [],
+          service_worker: [],
           state: [],
           netlog: [],
           installer: [],
@@ -143,29 +147,42 @@ describe('Sidebar', () => {
           mobile: [],
           chromium: [],
         },
+        logTypeFilter: defaultLogTypeFilter,
         bookmarks: [],
         isSidebarOpen: false,
       };
 
       render(<Sidebar state={state as SleuthState} />);
-      const fileTreeInner = screen.queryByRole('tree');
-      expect(fileTreeInner).toBeInTheDocument();
-      const fileTreeOuter = fileTreeInner?.parentElement;
-      expect(fileTreeOuter).not.toHaveClass('Open');
+      const fileTree = document.querySelector('.SidebarFileTree');
+      expect(fileTree).toBeInTheDocument();
+      expect(fileTree).not.toHaveClass('Open');
     });
 
-    it('does not show Trace section when no trace files exist', async () => {
+    it('shows all four desktop log types when files exist for each', async () => {
+      const installerFile: ProcessedLogFile = {
+        repeatedCounts: {},
+        id: 'inst1',
+        logEntries: [],
+        logFile: fakeUnzippedFile,
+        logType: LogType.INSTALLER,
+        type: 'ProcessedLogFile',
+        levelCounts: {},
+      };
+
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
+          epic_traces: [],
           webapp: [fakeFile3],
+          service_worker: [],
           state: [],
           netlog: [],
-          installer: [],
+          installer: [installerFile],
           trace: [],
           mobile: [],
           chromium: [fakeFile2],
         },
+        logTypeFilter: defaultLogTypeFilter,
         bookmarks: [],
       };
 
@@ -174,38 +191,7 @@ describe('Sidebar', () => {
       expect(await screen.findByText('Browser Process')).toBeInTheDocument();
       expect(await screen.findByText('WebApp')).toBeInTheDocument();
       expect(await screen.findByText('Chromium')).toBeInTheDocument();
-
-      const trace = screen.queryByText('Trace');
-      expect(trace).not.toBeInTheDocument();
-    });
-
-    it('shows Trace section when trace files exist', async () => {
-      const traceFile = {
-        fileName: 'performance.trace',
-        size: 1000,
-        fullPath: '/mock/path/asdf.trace',
-        id: 'trace1',
-        type: 'UnzippedFile' as const,
-      };
-
-      const state: Partial<SleuthState> = {
-        processedLogFiles: {
-          browser: [],
-          webapp: [],
-          state: [],
-          netlog: [],
-          installer: [],
-          trace: [traceFile],
-          mobile: [],
-          chromium: [],
-        },
-        bookmarks: [],
-      };
-
-      render(<Sidebar state={state as SleuthState} />);
-
-      const trace = await screen.findByText('Trace');
-      expect(trace).toBeInTheDocument();
+      expect(await screen.findByText('Installer')).toBeInTheDocument();
     });
   });
 });

--- a/test/renderer/components/sidebar.test.tsx
+++ b/test/renderer/components/sidebar.test.tsx
@@ -33,9 +33,9 @@ vi.mock(
 
 const defaultLogTypeFilter = {
   browser: true,
-  epic_traces: true,
+  rx_epic: true,
   webapp: true,
-  service_worker: true,
+  webapp_sw: true,
   chromium: true,
   installer: true,
   mobile: true,
@@ -77,9 +77,9 @@ describe('Sidebar', () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
-          epic_traces: [],
+          rx_epic: [],
           webapp: [fakeFile3],
-          service_worker: [],
+          webapp_sw: [],
           state: [],
           netlog: [],
           installer: [],
@@ -110,9 +110,9 @@ describe('Sidebar', () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [],
-          epic_traces: [],
+          rx_epic: [],
           webapp: [],
-          service_worker: [],
+          webapp_sw: [],
           state: [],
           netlog: [],
           installer: [],
@@ -137,9 +137,9 @@ describe('Sidebar', () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
-          epic_traces: [],
+          rx_epic: [],
           webapp: [],
-          service_worker: [],
+          webapp_sw: [],
           state: [],
           netlog: [],
           installer: [],
@@ -172,9 +172,9 @@ describe('Sidebar', () => {
       const state: Partial<SleuthState> = {
         processedLogFiles: {
           browser: [fakeFile1],
-          epic_traces: [],
+          rx_epic: [],
           webapp: [fakeFile3],
-          service_worker: [],
+          webapp_sw: [],
           state: [],
           netlog: [],
           installer: [installerFile],

--- a/test/utils/get-file-types.test.ts
+++ b/test/utils/get-file-types.test.ts
@@ -114,7 +114,7 @@ describe('getTypeForFile', () => {
     ).toEqual('browser');
   });
 
-  it('should get the type for browser-epics-trace.log as epic_traces', () => {
+  it('should get the type for browser-epics-trace.log as rx_epic', () => {
     expect(
       getTypeForFile({
         ...base,
@@ -122,10 +122,10 @@ describe('getTypeForFile', () => {
         fullPath: '_',
         size: 0,
       }),
-    ).toEqual('epic_traces');
+    ).toEqual('rx_epic');
   });
 
-  it('should get the type for webapp-service-worker-console.log as service_worker', () => {
+  it('should get the type for webapp-service-worker-console.log as webapp_sw', () => {
     expect(
       getTypeForFile({
         ...base,
@@ -133,7 +133,7 @@ describe('getTypeForFile', () => {
         fullPath: '_',
         size: 0,
       }),
-    ).toEqual('service_worker');
+    ).toEqual('webapp_sw');
   });
 
   it('should get the type for trace files', () => {

--- a/test/utils/get-file-types.test.ts
+++ b/test/utils/get-file-types.test.ts
@@ -114,6 +114,28 @@ describe('getTypeForFile', () => {
     ).toEqual('browser');
   });
 
+  it('should get the type for browser-epics-trace.log as epic_traces', () => {
+    expect(
+      getTypeForFile({
+        ...base,
+        fileName: 'browser-epics-trace.log',
+        fullPath: '_',
+        size: 0,
+      }),
+    ).toEqual('epic_traces');
+  });
+
+  it('should get the type for webapp-service-worker-console.log as service_worker', () => {
+    expect(
+      getTypeForFile({
+        ...base,
+        fileName: 'webapp-service-worker-console.log',
+        fullPath: '_',
+        size: 0,
+      }),
+    ).toEqual('service_worker');
+  });
+
   it('should get the type for trace files', () => {
     expect(
       getTypeForFile({

--- a/test/utils/match-tag.test.ts
+++ b/test/utils/match-tag.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { matchTag } from '../../src/utils/match-tag';
+
+describe('matchTag', () => {
+  it('matches webapp-style [TAG] prefixes', () => {
+    const result = matchTag('[HUDDLES] joined call');
+    expect(result).not.toBeNull();
+    expect(result![1]).toBe('HUDDLES');
+    expect(result![0]).toBe('[HUDDLES]');
+  });
+
+  it('matches browser-style Tag: prefixes', () => {
+    const result = matchTag('Store: UPDATE_SETTINGS');
+    expect(result).not.toBeNull();
+    expect(result![1]).toBe('Store');
+    expect(result![0]).toBe('Store:');
+  });
+
+  it('matches epic-style Tag = name; prefixes', () => {
+    const result = matchTag('Tag = fooBarEpic; rest');
+    expect(result).not.toBeNull();
+    expect(result![1]).toBe('fooBarEpic');
+    expect(result![0]).toBe('Tag = fooBarEpic;');
+  });
+
+  it('handles leading whitespace', () => {
+    const result = matchTag('  [SPACED TAG] msg');
+    expect(result).not.toBeNull();
+    expect(result![1]).toBe('SPACED TAG');
+    expect(result![0]).toBe('  [SPACED TAG]');
+  });
+
+  it('matches browser prefix with bracketed sub-tag', () => {
+    const result = matchTag('Store [sub-tag]: msg');
+    expect(result).not.toBeNull();
+    expect(result![1]).toBe('Store [sub-tag]');
+    expect(result![0]).toBe('Store [sub-tag]:');
+  });
+
+  it('returns null for messages without tags', () => {
+    expect(matchTag('no tag here')).toBeNull();
+  });
+
+  it('returns null for empty strings', () => {
+    expect(matchTag('')).toBeNull();
+  });
+});


### PR DESCRIPTION
This is a big PR that rethinks what the sidebar is used for. Please give it a spin manually with `yarn start`!

<img width="1913" height="1336" alt="image" src="https://github.com/user-attachments/assets/8d2766b6-420a-428d-8b8b-a512e9eb84d5" />

### Log IA revamp

At a high level, Sleuth now defaults to providing the former "All Desktop Logs" view to everyone to maximize context. Instead of viewing individual files in the Logs bundle, we now filter the _type_ of log on the client side, similar to how we can filter by Log Level already.

> [!NOTE]
> Installer logs are now properly added to the Log timeline so that you can inspect Squirrel updater logs in context.
>
> <img width="1104" height="366" alt="image" src="https://github.com/user-attachments/assets/74e18c36-a268-4046-b9aa-d8dceb0b590f" />

Speaking of Log Levels, that feature is also moved to the sidebar to make it easier to peek at your current log level state at a glance.

### Tags

Tags are now processed before logs are displayed (https://github.com/tinyspeck/sleuth/pull/309 used to just render them differently within the React component). This means that you can filter against specific tags in the sidebar UI.

### Traces and Net Logs

All other views that aren't actually log files are moved to their own tab.

<img width="1913" height="1336" alt="image" src="https://github.com/user-attachments/assets/2263b398-8740-4100-9413-c6b7e5bc64e4" />
