### PR TITLE
refactor: simplify selected file state

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -189,7 +189,6 @@ export interface RootState {
  * Context menu actions that can be taken on a specific log line.
  */
 export enum LogLineContextMenuActions {
-  SHOW_IN_CONTEXT,
   COPY_TO_CLIPBOARD,
   OPEN_SOURCE,
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,7 +7,6 @@ import {
   systemPreferences,
   IpcMainEvent,
   Menu,
-  MenuItemConstructorOptions,
   nativeTheme,
 } from 'electron';
 import path from 'node:path';
@@ -17,11 +16,7 @@ import { settingsFileManager } from './settings';
 import { changeIcon } from './app-icon';
 import { ICON_NAMES } from '../shared-constants';
 import { IpcEvents } from '../ipc-events';
-import {
-  LogLineContextMenuActions,
-  LogType,
-  UnzippedFile,
-} from '../interfaces';
+import { LogLineContextMenuActions, UnzippedFile } from '../interfaces';
 import { ColorTheme } from '../renderer/components/preferences/preferences';
 import { Unzipper } from './unzip';
 import { openFile } from './filesystem/open-file';
@@ -232,26 +227,8 @@ export class IpcManager {
   }
 
   private setupContextMenus() {
-    ipcMain.handle(IpcEvents.OPEN_LOG_CONTEXT_MENU, (event, type: LogType) => {
+    ipcMain.handle(IpcEvents.OPEN_LOG_CONTEXT_MENU, (event) => {
       return new Promise((resolve) => {
-        const maybeShowInContext: MenuItemConstructorOptions[] =
-          type === LogType.BROWSER ||
-          type === LogType.RX_EPIC ||
-          type === LogType.WEBAPP ||
-          type === LogType.SERVICE_WORKER
-            ? [
-                {
-                  type: 'separator',
-                },
-                {
-                  label: 'Show in "All Desktop Logs"',
-                  click: () => {
-                    resolve(LogLineContextMenuActions.SHOW_IN_CONTEXT);
-                  },
-                },
-              ]
-            : [];
-
         const menu = Menu.buildFromTemplate([
           {
             label: 'Copy Line',
@@ -265,7 +242,6 @@ export class IpcManager {
               resolve(LogLineContextMenuActions.OPEN_SOURCE);
             },
           },
-          ...maybeShowInContext,
         ]);
         menu.popup({
           window: BrowserWindow.fromWebContents(event.sender) || undefined,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -62,8 +62,8 @@ export const SleuthAPI = {
     ipcRenderer.invoke(IpcEvents.MESSAGE_BOX, options),
   changeIcon: (iconName: ICON_NAMES) =>
     ipcRenderer.invoke(IpcEvents.CHANGE_ICON, iconName),
-  showLogLineContextMenu: (type: LogType): Promise<LogLineContextMenuActions> =>
-    ipcRenderer.invoke(IpcEvents.OPEN_LOG_CONTEXT_MENU, type),
+  showLogLineContextMenu: (): Promise<LogLineContextMenuActions> =>
+    ipcRenderer.invoke(IpcEvents.OPEN_LOG_CONTEXT_MENU),
   setSetting: (key: string, value: unknown) =>
     ipcRenderer.invoke(IpcEvents.SET_SETTINGS, key, value),
   focusFind: (cb: () => void) => {

--- a/src/renderer/components/app-core.tsx
+++ b/src/renderer/components/app-core.tsx
@@ -245,7 +245,7 @@ export const CoreApplication = observer((props: CoreAppProps) => {
           if (toMerge.length > 0) {
             const allMerged = await mergeLogFiles(toMerge, LogType.ALL);
             setMergedFile(allMerged);
-            props.state.selectLogFile(null, LogType.ALL);
+            props.state.selectAllLogs();
           } else {
             // No browser/webapp logs to merge — select first available file
             const firstFile =
@@ -255,7 +255,7 @@ export const CoreApplication = observer((props: CoreAppProps) => {
               currentProcessed.netlog[0] ??
               currentProcessed.state[0];
             if (firstFile) {
-              props.state.selectLogFile(firstFile);
+              props.state.selectFile(firstFile);
             }
           }
         }

--- a/src/renderer/components/log-content.tsx
+++ b/src/renderer/components/log-content.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { observer } from 'mobx-react';
 
 import { isLogFile, isUnzippedFile } from '../../utils/is-logfile';
@@ -7,7 +7,7 @@ import { getFontForCSS } from './preferences/preferences-utils';
 import { LogTable } from './log-table';
 import { StateTable } from './state-table';
 import { SleuthState } from '../state/sleuth';
-import { ProcessedLogFile, LogType, TRACE_VIEWER } from '../../interfaces';
+import { LogFile, LogType, TRACE_VIEWER } from '../../interfaces';
 import { getTypeForFile } from '../../utils/get-file-types';
 import { LogLineDetails } from './log-line-details/details';
 import { LogTimeView } from './log-time-view';
@@ -22,6 +22,9 @@ export interface LogContentProps {
 
 export const LogContent = observer((props: LogContentProps) => {
   const [tableHeight, setTableHeight] = useState(600);
+  // Keep a ref to the last valid log file so the hidden LogTable always
+  // receives a proper LogFile even when selectedFile is a state/netlog/trace file.
+  const lastLogFileRef = useRef<LogFile | null>(null);
 
   const resizeHandler = useCallback((height: number) => {
     if (height < 100 || height > window.innerHeight - 100) return;
@@ -29,7 +32,7 @@ export const LogContent = observer((props: LogContentProps) => {
   }, []);
 
   const {
-    selectedLogFile,
+    selectedFile,
     levelFilter,
     search,
     dateTimeFormat_v4: dateTimeFormat,
@@ -41,8 +44,23 @@ export const LogContent = observer((props: LogContentProps) => {
     selectedEntry,
   } = props.state;
 
-  if (!selectedLogFile) return null;
-  const isLog = isLogFile(selectedLogFile);
+  if (!selectedFile) {
+    lastLogFileRef.current = null;
+    return null;
+  }
+
+  const isLog = isLogFile(selectedFile);
+  if (isLog) {
+    lastLogFileRef.current = selectedFile;
+  }
+  const logFileForTable = isLog ? selectedFile : lastLogFileRef.current;
+
+  const isUnzipped = isUnzippedFile(selectedFile);
+  const logType = isUnzipped ? getTypeForFile(selectedFile) : null;
+  const isNetlog = logType === LogType.NETLOG;
+  const isTrace = logType === LogType.TRACE;
+  const isState = isUnzipped && !isNetlog && !isTrace;
+
   const scrubber = (
     <Scrubber
       elementSelector="LogTableContainer"
@@ -50,49 +68,56 @@ export const LogContent = observer((props: LogContentProps) => {
     />
   );
 
-  // In most cases, we're dealing with a log file
-  if (isLog) {
-    return (
-      <div className="LogContent" style={{ fontFamily: getFontForCSS(font) }}>
-        <div className="AppHeader">
-          <Filter state={props.state} />
-        </div>
-        <div id="LogTableContainer" style={{ height: tableHeight }}>
-          <LogTable
-            state={props.state}
-            dateTimeFormat={dateTimeFormat}
-            logFile={selectedLogFile as ProcessedLogFile}
-            levelFilter={levelFilter}
-            search={search}
-            searchIndex={searchIndex}
-            searchList={searchList}
-            showOnlySearchResults={showOnlySearchResults}
-            dateRange={dateRange}
-            selectedEntry={selectedEntry}
-          />
-        </div>
-        {scrubber}
-        <LogLineDetails state={props.state} />
-        <LogTimeView state={props.state} />
-      </div>
-    );
-  }
-
-  // If we're not a log file, we're probably a state file
-  if (isUnzippedFile(selectedLogFile)) {
-    const logType = getTypeForFile(selectedLogFile);
-
-    if (logType === LogType.NETLOG) {
-      return <NetLogView file={selectedLogFile} state={props.state} />;
-    } else if (logType === LogType.TRACE) {
-      return props.state.selectedTraceViewer ===
-        TRACE_VIEWER.CHROME_DEVTOOLS ? (
-        <DevtoolsView file={selectedLogFile} state={props.state} />
-      ) : (
-        <PerfettoView file={selectedLogFile} state={props.state} />
-      );
+  // Non-log views are rendered on-demand since they depend on the selected file
+  let nonLogView: React.ReactNode = null;
+  if (!isLog) {
+    if (isNetlog) {
+      nonLogView = <NetLogView file={selectedFile} state={props.state} />;
+    } else if (isTrace) {
+      nonLogView =
+        props.state.selectedTraceViewer === TRACE_VIEWER.CHROME_DEVTOOLS ? (
+          <DevtoolsView file={selectedFile} state={props.state} />
+        ) : (
+          <PerfettoView file={selectedFile} state={props.state} />
+        );
+    } else if (isState) {
+      nonLogView = <StateTable state={props.state} />;
     }
   }
 
-  return <StateTable state={props.state} />;
+  return (
+    <>
+      {logFileForTable && (
+        <div
+          className="LogContent"
+          style={{
+            fontFamily: getFontForCSS(font),
+            display: isLog ? undefined : 'none',
+          }}
+        >
+          <div className="AppHeader">
+            <Filter state={props.state} />
+          </div>
+          <div id="LogTableContainer" style={{ height: tableHeight }}>
+            <LogTable
+              state={props.state}
+              dateTimeFormat={dateTimeFormat}
+              logFile={logFileForTable}
+              levelFilter={levelFilter}
+              search={search}
+              searchIndex={searchIndex}
+              searchList={searchList}
+              showOnlySearchResults={showOnlySearchResults}
+              dateRange={dateRange}
+              selectedEntry={selectedEntry}
+            />
+          </div>
+          {scrubber}
+          <LogLineDetails state={props.state} />
+          <LogTimeView state={props.state} />
+        </div>
+      )}
+      {nonLogView}
+    </>
+  );
 });

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -28,7 +28,6 @@ import {
   LogType,
   ProcessableLogType,
   LogLineContextMenuActions,
-  LogFile,
 } from '../../interfaces';
 import { isReduxAction } from '../../utils/is-redux-action';
 import { LogTableProps, SortFilterListOptions } from './log-table-constants';
@@ -246,10 +245,9 @@ export const LogTable = observer((props: LogTableProps) => {
         (!sortDir || sortDir === SortDirection.ASC);
 
       // Check if we can bail early and just use the naked logEntries array
-      const hasLogTypeFilter =
-        isMergedLogFile(file) &&
-        file.logType === LogType.ALL &&
-        !Object.values(state.logTypeFilter).every(Boolean);
+      const hasLogTypeFilter = !Object.values(state.logTypeFilter).every(
+        Boolean,
+      );
       const hasTagFilter = state.selectedTags.length > 0;
       if (
         noSort &&
@@ -285,15 +283,11 @@ export const LogTable = observer((props: LogTableProps) => {
         list = list.filter(doFilter);
       }
 
-      // LogType filter (for merged ALL view)
-      if (isMergedLogFile(file) && file.logType === LogType.ALL) {
-        const { logTypeFilter } = state;
-        const allEnabled = Object.values(logTypeFilter).every(Boolean);
-        if (!allEnabled) {
-          list = list.filter(
-            (entry) => logTypeFilter[entry.logType as ProcessableLogType],
-          );
-        }
+      // LogType filter
+      if (hasLogTypeFilter) {
+        list = list.filter(
+          (entry) => state.logTypeFilter[entry.logType as ProcessableLogType],
+        );
       }
 
       // Tag filter
@@ -435,11 +429,7 @@ export const LogTable = observer((props: LogTableProps) => {
     async (params: RowMouseEventHandlerParams) => {
       try {
         const rowData: LogEntry = params.rowData;
-        const selectedLogFile = state.selectedLogFile as LogFile | undefined;
-        if (!selectedLogFile) return;
-
-        const logType = selectedLogFile.logType;
-        const response = await window.Sleuth.showLogLineContextMenu(logType);
+        const response = await window.Sleuth.showLogLineContextMenu();
 
         switch (response) {
           case LogLineContextMenuActions.COPY_TO_CLIPBOARD: {
@@ -461,10 +451,6 @@ export const LogTable = observer((props: LogTableProps) => {
             });
             break;
           }
-          case LogLineContextMenuActions.SHOW_IN_CONTEXT:
-            state.setPendingScrollToMoment(rowData.momentValue);
-            state.selectLogFile(null, LogType.ALL);
-            break;
         }
       } catch (error) {
         d('Error in context menu handler:', error);
@@ -734,21 +720,19 @@ export const LogTable = observer((props: LogTableProps) => {
           flexGrow={0}
         />
         <Column label="Level" dataKey="level" width={80} />
-        {logFile.logType === LogType.ALL ? (
-          <Column
-            label="Process"
-            dataKey="logType"
-            width={100}
-            cellRenderer={({ cellData }: TableCellProps) => (
-              <Tag
-                color={logColorMap[cellData as ProcessableLogType] ?? 'default'}
-                style={PROCESS_TAG_STYLE}
-              >
-                {cellData}
-              </Tag>
-            )}
-          />
-        ) : null}
+        <Column
+          label="Process"
+          dataKey="logType"
+          width={100}
+          cellRenderer={({ cellData }: TableCellProps) => (
+            <Tag
+              color={logColorMap[cellData as ProcessableLogType] ?? 'default'}
+              style={PROCESS_TAG_STYLE}
+            >
+              {cellData}
+            </Tag>
+          )}
+        />
         <Column
           label="Message"
           dataKey="message"
@@ -835,25 +819,6 @@ export const LogTable = observer((props: LogTableProps) => {
       scrollToSelectionRef.current = true;
     }
   }, []);
-
-  // Handle pending scroll-to-moment (e.g. from "Show in All Desktop Logs").
-  // When the user triggers "Show in Context", we set the pending moment and
-  // switch to the ALL view. The sortedList may not yet reflect the new file,
-  // so we wait until the list is populated before attempting to find the entry.
-  useEffect(() => {
-    const { pendingScrollToMoment } = state;
-    if (pendingScrollToMoment === undefined) return;
-    if (sortedList.length === 0) return;
-
-    const matchingIndex = sortedList.findIndex(
-      (row) => row.momentValue === pendingScrollToMoment,
-    );
-
-    if (matchingIndex >= 0) {
-      changeSelection(matchingIndex);
-    }
-    state.setPendingScrollToMoment(undefined);
-  }, [state.pendingScrollToMoment, sortedList, changeSelection]);
 
   // Keyboard navigation handler — listen on document to match
   // the previous global behavior (react-keydown listened globally)

--- a/src/renderer/components/log-time-view.tsx
+++ b/src/renderer/components/log-time-view.tsx
@@ -25,9 +25,9 @@ export const LogTimeView = observer((props: LogTimeViewProps) => {
 
     const dataX = chart.scales.x.getValueForPixel(canvasPosition.x);
 
-    const { selectedLogFile } = props.state;
-    if (isLogFile(selectedLogFile)) {
-      const { logEntries } = selectedLogFile;
+    const { selectedFile } = props.state;
+    if (isLogFile(selectedFile)) {
+      const { logEntries } = selectedFile;
       const selectedEntry = logEntries.find((entry) => {
         return (
           parse(entry.timestamp, 'MM/dd/yy, HH:mm:ss:SSS', new Date()) >= dataX
@@ -43,8 +43,8 @@ export const LogTimeView = observer((props: LogTimeViewProps) => {
     props.state.customTimeViewRange = until - from;
   }
 
-  const { selectedLogFile, isLogViewVisible, isUserTZ } = props.state;
-  if (!isLogViewVisible || !selectedLogFile || !isLogFile(selectedLogFile))
+  const { selectedFile, isLogViewVisible, isUserTZ } = props.state;
+  if (!isLogViewVisible || !selectedFile || !isLogFile(selectedFile))
     return null;
 
   const className = classNames('Details', { IsVisible: isLogViewVisible });
@@ -84,7 +84,7 @@ export const LogTimeView = observer((props: LogTimeViewProps) => {
     <div className={className}>
       <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <ChartJSChart
-          key={selectedLogFile.id}
+          key={selectedFile.id}
           type="bar"
           data={{
             datasets,

--- a/src/renderer/components/sidebar/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar/sidebar-file-tree.tsx
@@ -155,7 +155,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
 
       const file = files.get(selected);
       if (file) {
-        props.state.selectLogFile(file);
+        props.state.selectFile(file);
       }
     },
     [props.state, files],
@@ -200,7 +200,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
         (f) => f.id === fileId,
       );
       if (file) {
-        props.state.selectLogFile(file);
+        props.state.selectFile(file);
       }
     },
     [props.state],
@@ -210,13 +210,13 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
   const onLogTypeToggle = useCallback(
     (key: string, checked: boolean) => {
       props.state.setLogTypeFilter({ [key]: checked });
-      const { selectedLogFile } = props.state;
+      const { selectedFile } = props.state;
       if (
-        !selectedLogFile ||
-        !isMergedLogFile(selectedLogFile) ||
-        selectedLogFile.logType !== LogType.ALL
+        !selectedFile ||
+        !isMergedLogFile(selectedFile) ||
+        selectedFile.logType !== LogType.ALL
       ) {
-        props.state.selectLogFile(null, LogType.ALL);
+        props.state.selectAllLogs();
       }
     },
     [props.state],
@@ -244,13 +244,13 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
       ) as Partial<LogTypeFilter>;
       props.state.setLogTypeFilter(filter);
 
-      const { selectedLogFile } = props.state;
+      const { selectedFile } = props.state;
       if (
-        !selectedLogFile ||
-        !isMergedLogFile(selectedLogFile) ||
-        selectedLogFile.logType !== LogType.ALL
+        !selectedFile ||
+        !isMergedLogFile(selectedFile) ||
+        selectedFile.logType !== LogType.ALL
       ) {
-        props.state.selectLogFile(null, LogType.ALL);
+        props.state.selectAllLogs();
       }
     },
     [props.state],
@@ -291,13 +291,13 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     [props.state],
   );
 
-  const { isSidebarOpen, selectedLogFile, logTypeFilter, processedLogFiles } =
+  const { isSidebarOpen, selectedFile, logTypeFilter, processedLogFiles } =
     props.state;
 
   function getSelectedKey(): string | undefined {
-    if (!selectedLogFile) return undefined;
-    if (isMergedLogFile(selectedLogFile)) return selectedLogFile.logType;
-    if ('id' in selectedLogFile) return selectedLogFile.id;
+    if (!selectedFile) return undefined;
+    if (isMergedLogFile(selectedFile)) return selectedFile.logType;
+    if ('id' in selectedFile) return selectedFile.id;
     return undefined;
   }
 
@@ -307,9 +307,9 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
     ? stateNodes.some((node) => node.key === selectedKey)
     : false;
   const isTraceFileSelected =
-    selectedLogFile &&
-    'fileName' in selectedLogFile &&
-    selectedLogFile.fileName.endsWith('.trace');
+    selectedFile &&
+    'fileName' in selectedFile &&
+    selectedFile.fileName.endsWith('.trace');
   const isNetlogFileSelected = selectedKey
     ? (processedLogFiles?.netlog?.some((f) => f.id === selectedKey) ?? false)
     : false;
@@ -530,7 +530,7 @@ const SidebarFileTree = observer((props: SidebarFileTreeProps) => {
         onChange={(key) => {
           setManualTab(key);
           if (key === 'logs' && derivedTab !== 'logs') {
-            props.state.selectLogFile(null, LogType.ALL);
+            props.state.selectAllLogs();
           }
         }}
         size="small"

--- a/src/renderer/components/spotlight.tsx
+++ b/src/renderer/components/spotlight.tsx
@@ -36,7 +36,7 @@ export const Spotlight = observer((props: SpotlightProps): JSX.Element => {
       openFile,
       processedLogFiles,
       reset,
-      selectLogFile,
+      selectFile,
       suggestions,
       toggleSidebar,
     } = props.state;
@@ -86,7 +86,7 @@ export const Spotlight = observer((props: SpotlightProps): JSX.Element => {
               ),
               value: logFile.logFile.fileName,
               click: () => {
-                selectLogFile(logFile);
+                selectFile(logFile);
               },
             });
           } else {
@@ -102,7 +102,7 @@ export const Spotlight = observer((props: SpotlightProps): JSX.Element => {
               ),
               value: logFile.fileName,
               click: () => {
-                selectLogFile(logFile);
+                selectFile(logFile);
               },
             });
           }

--- a/src/renderer/components/state-table.tsx
+++ b/src/renderer/components/state-table.tsx
@@ -69,38 +69,36 @@ function isRootStateFile(file: UnzippedFile) {
   return file.fullPath.endsWith('root-state.json');
 }
 
-function getFileType(
-  selectedLogFile: SelectableLogFile | undefined,
-): StateType {
-  if (!isStateFile(selectedLogFile)) {
+function getFileType(selectedFile: SelectableLogFile | undefined): StateType {
+  if (!isStateFile(selectedFile)) {
     throw new Error('StateTable: No file');
   }
 
-  if (isHtmlFile(selectedLogFile)) {
+  if (isHtmlFile(selectedFile)) {
     return StateType.html;
   }
 
-  if (isNotifsFile(selectedLogFile)) {
+  if (isNotifsFile(selectedFile)) {
     return StateType.notifs;
   }
 
-  if (isInstallationFile(selectedLogFile)) {
+  if (isInstallationFile(selectedFile)) {
     return StateType.installation;
   }
 
-  if (isRootStateFile(selectedLogFile)) {
+  if (isRootStateFile(selectedFile)) {
     return StateType.rootState;
   }
 
-  if (isExternalConfigFile(selectedLogFile)) {
+  if (isExternalConfigFile(selectedFile)) {
     return StateType.externalConfig;
   }
 
-  if (selectedLogFile.fileName === 'environment.json') {
+  if (selectedFile.fileName === 'environment.json') {
     return StateType.environment;
   }
 
-  if (selectedLogFile.fileName === 'local-settings.json') {
+  if (selectedFile.fileName === 'local-settings.json') {
     return StateType.localSettings;
   }
 
@@ -110,17 +108,17 @@ function getFileType(
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export const StateTable = observer(({ state }: StateTableProps) => {
   const fileState = useMemo(() => {
-    const { selectedLogFile } = state;
-    if (isStateFile(selectedLogFile)) {
-      return state.stateFiles[selectedLogFile.fileName] ?? {};
+    const { selectedFile } = state;
+    if (isStateFile(selectedFile)) {
+      return state.stateFiles[selectedFile.fileName] ?? {};
     }
     return {};
-  }, [state, state.selectedLogFile]);
+  }, [state, state.selectedFile]);
 
   const { data, path, raw } = fileState;
-  const { font, selectedLogFile } = state;
+  const { font, selectedFile } = state;
 
-  const type = getFileType(selectedLogFile);
+  const type = getFileType(selectedFile);
 
   const renderNotifsInfo = (): JSX.Element | null => {
     if (!Array.isArray(data) || data.length === 0) {

--- a/src/renderer/state/bookmarks.ts
+++ b/src/renderer/state/bookmarks.ts
@@ -29,7 +29,7 @@ export function goToBookmark(state: SleuthState, bookmark: Bookmark) {
 
   d(`Going to ${bookmark.logFile.id} at line ${bookmark.logEntry.line}`);
 
-  state.selectedLogFile = bookmark.logFile;
+  state.selectFile(bookmark.logFile);
   state.selectedEntry = bookmark.logEntry;
 }
 
@@ -43,18 +43,18 @@ export function goToBookmark(state: SleuthState, bookmark: Bookmark) {
 export function getBookmark(state: SleuthState): Bookmark | undefined {
   // No point in saving a bookmark unless we have
   // a path
-  if (!state.selectedEntry || !state.selectedLogFile || !state.selectedIndex) {
+  if (!state.selectedEntry || !state.selectedFile || !state.selectedIndex) {
     return;
   }
 
   // Don't bookmark tools and unzipped files
-  if (!isProcessedLogFile(state.selectedLogFile)) {
+  if (!isProcessedLogFile(state.selectedFile)) {
     return;
   }
 
   const bookmark: Bookmark = {
     logEntry: state.selectedEntry,
-    logFile: state.selectedLogFile,
+    logFile: state.selectedFile,
   };
 
   return bookmark;

--- a/src/renderer/state/sleuth.ts
+++ b/src/renderer/state/sleuth.ts
@@ -11,7 +11,7 @@ import debug from 'debug';
 import { testDateTimeFormat } from '../../utils/test-date-time';
 import { SortDirection, SortDirectionType } from 'react-virtualized';
 import { setSetting } from '../settings';
-import { isProcessedLogFile } from '../../utils/is-logfile';
+import { isLogFile } from '../../utils/is-logfile';
 import { getFileName } from '../../utils/get-file-name';
 
 import {
@@ -19,20 +19,16 @@ import {
   LogEntry,
   LogTypeFilter,
   MergedLogFile,
-  ProcessedLogFile,
   DateRange,
   Bookmark,
   MergedLogFiles,
-  UnzippedFile,
   SelectableLogFile,
   ProcessedLogFiles,
   SerializedBookmark,
   TimeBucketedLogMetrics,
   LogLevel,
   LogType,
-  KnownLogType,
   Suggestion,
-  SelectableLogType,
   TRACE_VIEWER,
   LOG_TYPES_TO_PROCESS,
 } from '../../interfaces';
@@ -68,18 +64,10 @@ export class SleuthState {
   @observable.ref public selectedRangeEntries?: Array<LogEntry>;
   // The custom range of the log time view
   @observable public customTimeViewRange: number | undefined;
-  // When set, the log table should scroll to the entry with this momentValue
-  @observable public pendingScrollToMoment?: number;
-
-  @action
-  public setPendingScrollToMoment(moment: number | undefined) {
-    this.pendingScrollToMoment = moment;
-  }
-
   // Path to the source directory (zip file, folder path, etc)
   @observable public source?: string;
   // A reference to the selected log file
-  @observable.ref public selectedLogFile?: SelectableLogFile;
+  @observable.ref public selectedFile?: SelectableLogFile;
 
   // ** Search and Filter **
   @observable public levelFilter: LevelFilter = {
@@ -121,7 +109,7 @@ export class SleuthState {
   @observable public selectedTracePid?: number;
 
   @observable
-  public selectedTraceViewer: TRACE_VIEWER;
+  public selectedTraceViewer: TRACE_VIEWER | undefined;
 
   // ** Settings **
   @observable public colorTheme = this.retrieve<ColorTheme>('colorTheme', {
@@ -218,7 +206,7 @@ export class SleuthState {
     this.reset = this.reset.bind(this);
     this.toggleSidebar = this.toggleSidebar.bind(this);
     this.toggleSpotlight = this.toggleSpotlight.bind(this);
-    this.selectLogFile = this.selectLogFile.bind(this);
+    this.selectFile = this.selectFile.bind(this);
     this.setMergedFile = this.setMergedFile.bind(this);
     this.setFilterLogLevels = this.setFilterLogLevels.bind(this);
 
@@ -251,21 +239,19 @@ export class SleuthState {
    */
   @computed
   public get selectedFileName(): string {
-    return this.selectedLogFile ? getFileName(this.selectedLogFile) : '';
+    return this.selectedFile ? getFileName(this.selectedFile) : '';
   }
 
   @computed
   public get initialTimeViewRange(): number {
-    return this.selectedLogFile
-      ? getInitialTimeViewRange(this.selectedLogFile)
-      : 0;
+    return this.selectedFile ? getInitialTimeViewRange(this.selectedFile) : 0;
   }
 
   @computed
   public get timeBucketedLogMetrics(): TimeBucketedLogMetrics {
     const range = this.customTimeViewRange || this.initialTimeViewRange;
-    return this.selectedLogFile
-      ? getTimeBucketedLogMetrics(this.selectedLogFile, range)
+    return this.selectedFile
+      ? getTimeBucketedLogMetrics(this.selectedFile, range)
       : {};
   }
 
@@ -323,7 +309,7 @@ export class SleuthState {
     this.mergedLogFiles = undefined;
     this.selectedEntry = undefined;
     this.selectedIndex = undefined;
-    this.selectedLogFile = undefined;
+    this.selectedFile = undefined;
     this.bookmarks = [];
     this.levelFilter.debug = true;
     this.levelFilter.error = true;
@@ -345,35 +331,25 @@ export class SleuthState {
     }
   }
 
-  /**
-   * Select a log file. This is a more complex operation than one might think -
-   * mostly because we might need to create a merged file on-the-fly.
-   */
   @action
-  public selectLogFile(
-    logFile: ProcessedLogFile | UnzippedFile | null,
-    logType?: SelectableLogType,
-  ): void {
+  public selectFile(logFile: SelectableLogFile): void {
     this.selectedEntry = undefined;
     this.selectedRangeEntries = undefined;
     this.selectedRangeIndex = undefined;
     this.selectedIndex = undefined;
     this.customTimeViewRange = undefined;
 
-    if (logFile) {
-      const name = isProcessedLogFile(logFile)
-        ? logFile.logType
-        : logFile.fileName;
-      d(`Selecting log file ${name}`);
+    const name = isLogFile(logFile) ? logFile.logType : logFile.fileName;
+    d(`Selecting log file ${name}`);
 
-      this.selectedLogFile = logFile;
-    } else if (
-      logType &&
-      Object.values(LogType).includes(logType as LogType) &&
-      this.mergedLogFiles
-    ) {
-      d(`Selecting log type ${logType}`);
-      this.selectedLogFile = this.mergedLogFiles[logType as KnownLogType];
+    this.selectedFile = logFile;
+  }
+
+  @action
+  public selectAllLogs(): void {
+    const allMerged = this.mergedLogFiles?.[LogType.ALL];
+    if (allMerged) {
+      this.selectFile(allMerged);
     }
   }
 
@@ -427,7 +403,7 @@ export class SleuthState {
 
     const firstTraceFile = this.processedLogFiles?.trace[0];
     if (firstTraceFile) {
-      this.selectLogFile(firstTraceFile);
+      this.selectFile(firstTraceFile);
     }
   }
 

--- a/src/renderer/state/time-view.ts
+++ b/src/renderer/state/time-view.ts
@@ -34,15 +34,15 @@ function getBucket(range: number, momentValue: number): number {
  * @returns {TimeBucketedLogMetrics} timeBucketedLogMetrics
  */
 export function getTimeBucketedLogMetrics(
-  selectedLogFile: SelectableLogFile,
+  selectedFile: SelectableLogFile,
   range: number,
 ): TimeBucketedLogMetrics {
-  if (!isLogFile(selectedLogFile)) {
+  if (!isLogFile(selectedFile)) {
     return {};
   }
 
   const values: TimeBucketedLogMetrics = {};
-  for (const entry of selectedLogFile.logEntries) {
+  for (const entry of selectedFile.logEntries) {
     if (entry.momentValue) {
       const bucket = getBucket(range, entry.momentValue);
       values[bucket] = values[bucket] || {
@@ -62,15 +62,15 @@ export function getTimeBucketedLogMetrics(
  * Get initial range (difference between highest and lowest timestamp) from the selected log file
  */
 export function getInitialTimeViewRange(
-  selectedLogFile: SelectableLogFile,
+  selectedFile: SelectableLogFile,
 ): number {
-  if (!isLogFile(selectedLogFile) || selectedLogFile.logEntries.length === 0) {
+  if (!isLogFile(selectedFile) || selectedFile.logEntries.length === 0) {
     return 0;
   }
 
   let min = Number.MAX_SAFE_INTEGER;
   let max = 0;
-  for (const { momentValue } of selectedLogFile.logEntries) {
+  for (const { momentValue } of selectedFile.logEntries) {
     if (!momentValue) continue;
 
     if (momentValue < min) {

--- a/src/renderer/state/touchbar.ts
+++ b/src/renderer/state/touchbar.ts
@@ -10,11 +10,11 @@ export function setupTouchBarAutoruns(state: SleuthState) {
   });
 
   autorun(() => {
-    const levelCounts = isProcessedLogFile(state.selectedLogFile)
-      ? state.selectedLogFile.levelCounts
+    const levelCounts = isProcessedLogFile(state.selectedFile)
+      ? state.selectedFile.levelCounts
       : {};
     const options: TouchBarLogFileUpdate = {
-      isLogFile: isLogFile(state.selectedLogFile),
+      isLogFile: isLogFile(state.selectedFile),
       levelCounts,
     };
 


### PR DESCRIPTION
#311 refactored the log viewer bits to always show the old "All Desktop Logs" view. Now, there's no point anymore in keeping logic under the hood for the concept of "selected log files".

This PR renames `selectedLogFile` to `selectedFile`, and trims away code that assumed that you could view multiple types of log files.
