### PR TITLE
fix(search): corner cases in filtering logic

### DIFF
--- a/src/renderer/components/app-core-header-filter.tsx
+++ b/src/renderer/components/app-core-header-filter.tsx
@@ -1,4 +1,5 @@
 import { observer } from 'mobx-react';
+import { runInAction } from 'mobx';
 import React, { useEffect } from 'react';
 import { debounce } from 'lodash';
 import {
@@ -38,41 +39,28 @@ export const Filter = observer((props: FilterProps) => {
    * @param change 1 or -1, normally
    */
   const handleSearchIndexChange = (change: number) => {
-    const { searchList, searchIndex, selectedIndex } = props.state;
-    // noop if we have no search results at the moment
-    if (searchList.length === 0 || selectedIndex === undefined) {
+    const { searchList, searchIndex } = props.state;
+    if (searchList.length === 0) {
       return;
     }
-    let newSearchIndex = 0;
 
-    if (selectedIndex === searchList[searchIndex]) {
-      const numSearchResults = searchList.length;
-      newSearchIndex = searchIndex + change;
-      if (newSearchIndex >= numSearchResults) {
-        newSearchIndex = 0;
-      } else if (newSearchIndex < 0) {
-        newSearchIndex = numSearchResults - 1;
-      }
-    } else {
-      // if we're currently selecting a row that isn't in the search result list,
-      // we want the arrow keys to point us back to the nearest search result in that
-      // direction. This is kind of what VSCode does for its search arrows.
-      // For positive change, we just want the next largest search index but for negative
-      // change, we want the previous one so we offset by -1 indices.
-      const offset = change > 0 ? 0 : -1;
-      for (const [index, searchIndex] of searchList.entries()) {
-        if (searchIndex > selectedIndex) {
-          newSearchIndex = index + offset;
-          break;
-        }
-      }
+    let newSearchIndex = searchIndex + change;
+    if (newSearchIndex >= searchList.length) {
+      newSearchIndex = 0;
+    } else if (newSearchIndex < 0) {
+      newSearchIndex = searchList.length - 1;
     }
 
-    props.state.searchIndex = newSearchIndex;
+    runInAction(() => {
+      props.state.searchIndex = newSearchIndex;
+    });
   };
 
   const handleSearchQueryChange = debounce((value: string) => {
-    props.state.search = value;
+    runInAction(() => {
+      props.state.search = value;
+      props.state.searchIndex = 0;
+    });
   }, 500);
 
   const handleDateRangeChange = (values: [Date, Date]) => {

--- a/src/renderer/components/log-table.tsx
+++ b/src/renderer/components/log-table.tsx
@@ -784,6 +784,14 @@ export const LogTable = observer((props: LogTableProps) => {
     });
   }, [sortedList, state, state.selectedEntry]);
 
+  // Scroll to selected entry when showOnlySearchResults is toggled
+  useEffect(() => {
+    if (state.selectedEntry) {
+      scrollToSelectionRef.current = true;
+      setIgnoreSearchIndex(true);
+    }
+  }, [showOnlySearchResults, state]);
+
   // Scroll to selection when a bookmark is activated (selectedEntry prop changes)
   useEffect(() => {
     if (selectedEntry !== state.selectedEntry) {

--- a/test/renderer/components/app-core-header-filter.test.tsx
+++ b/test/renderer/components/app-core-header-filter.test.tsx
@@ -424,4 +424,92 @@ describe('Filter', () => {
       expect(tzSwitch.parentElement).toBeInTheDocument();
     });
   });
+
+  describe('Search Navigation', () => {
+    function makeState(
+      overrides: Partial<SleuthState> = {},
+    ): Partial<SleuthState> {
+      return {
+        isUserTZ: false,
+        stateFiles: {
+          'log-context.json': { data: {} } as any,
+        },
+        searchList: [],
+        searchIndex: 0,
+        levelFilter: { error: true, warn: true, info: true, debug: true },
+        dateRange: { from: null, to: null },
+        ...overrides,
+      };
+    }
+
+    function getArrowButton(direction: 'up' | 'down'): HTMLElement {
+      const icon = screen.getByLabelText(`arrow-${direction}`);
+      return icon.closest('button')!;
+    }
+
+    it('wraps searchIndex to the last result when pressing up at index 0', () => {
+      const state = makeState({
+        searchList: [10, 20, 30],
+        searchIndex: 0,
+      });
+
+      render(<Filter state={state as SleuthState} />);
+      fireEvent.click(getArrowButton('up'));
+
+      expect(state.searchIndex).toBe(2);
+    });
+
+    it('wraps searchIndex to 0 when pressing down at the last result', () => {
+      const state = makeState({
+        searchList: [10, 20, 30],
+        searchIndex: 2,
+      });
+
+      render(<Filter state={state as SleuthState} />);
+      fireEvent.click(getArrowButton('down'));
+
+      expect(state.searchIndex).toBe(0);
+    });
+
+    it('increments searchIndex normally when not at a boundary', () => {
+      const state = makeState({
+        searchList: [10, 20, 30],
+        searchIndex: 0,
+      });
+
+      render(<Filter state={state as SleuthState} />);
+      fireEvent.click(getArrowButton('down'));
+
+      expect(state.searchIndex).toBe(1);
+    });
+
+    it('decrements searchIndex normally when not at a boundary', () => {
+      const state = makeState({
+        searchList: [10, 20, 30],
+        searchIndex: 2,
+      });
+
+      render(<Filter state={state as SleuthState} />);
+      fireEvent.click(getArrowButton('up'));
+
+      expect(state.searchIndex).toBe(1);
+    });
+
+    it('resets searchIndex to 0 when the search query changes', async () => {
+      const state = makeState({
+        searchList: [10, 20, 30],
+        searchIndex: 2,
+        search: 'old query',
+      });
+
+      render(<Filter state={state as SleuthState} />);
+
+      const searchInput = screen.getByPlaceholderText('Search');
+      fireEvent.change(searchInput, { target: { value: 'new query' } });
+
+      await waitFor(() => {
+        expect(state.searchIndex).toBe(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Some faulty logic in our search results made:

1) Rolling search indexes backwards (e.g. from `1/N` to `N/N`) break occasionally.
2) Hiding/showing search results only not focus the right log line.

This does change scrolling between search results when you have another line selected (added in https://github.com/tinyspeck/sleuth/pull/135), but I think fixing the jank is better.