### PR TITLE
build: cut over macOS code signing to KMS-Ferry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,9 @@ jobs:
       code_signer:
         type: string
         default: 'tinyspeck/aws-ansible-code-signer-prod'
+      use_kms:
+        type: string
+        default: 'false'
     steps:
       - run:
           command: |
@@ -192,7 +195,8 @@ jobs:
                     --arg ct "" \
                     --arg cs "$CIRCLE_SHA1" \
                     --arg rc << parameters.code_signer >> \
-                    '{JOB_NAME: $j, ARTIFACTS_DIR: $ad, DARWIN_PLATFORM: $mas, PROD_NAME: $pn, CIRCLE_TAG: $ct, CIRCLE_SHA1: $cs, RESOURCE_CLASS: $rc}'
+                    --arg kms "<< parameters.use_kms >>" \
+                    '{JOB_NAME: $j, ARTIFACTS_DIR: $ad, DARWIN_PLATFORM: $mas, PROD_NAME: $pn, CIRCLE_TAG: $ct, CIRCLE_SHA1: $cs, RESOURCE_CLASS: $rc, USE_KMS: $kms}'
             )
             if [ -n "${CIRCLE_TAG}" ]; then export GIT_REF=$CIRCLE_TAG; else export GIT_REF=$CIRCLE_BRANCH; fi
             sudo /Library/circleci/runner-entrypoint.sh master "$JOB_PARAMS"
@@ -272,6 +276,47 @@ workflows:
           requires:
             - build-macos-universal
           arch: universal
+          filters:
+            branches:
+              only: main
+            <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
+      # KMS code-sign jobs run side-by-side with existing jobs (informational only).
+      # publish depends only on the original code-sign jobs above.
+      - code-sign-macos:
+          name: code-sign-kms-macos-x64
+          requires:
+            - build-macos-x64
+          arch: x64
+          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
+          use_kms: 'true'
+          filters:
+            branches:
+              only: main
+            <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
+      - code-sign-macos:
+          name: code-sign-kms-macos-arm64
+          requires:
+            - build-macos-arm64
+          arch: arm64
+          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
+          use_kms: 'true'
+          filters:
+            branches:
+              only: main
+            <<: *job_filter_releases
+          context:
+            - sleuth-code-signing
+      - code-sign-macos:
+          name: code-sign-kms-macos-universal
+          requires:
+            - build-macos-universal
+          arch: universal
+          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
+          use_kms: 'true'
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,9 +256,7 @@ workflows:
           arch: x64
           filters:
             branches:
-              only:
-                - main
-                - dlish/add-kms-macos-signing
+              only: main
             <<: *job_filter_releases
           context:
             - sleuth-code-signing
@@ -269,9 +267,7 @@ workflows:
           arch: arm64
           filters:
             branches:
-              only:
-                - main
-                - dlish/add-kms-macos-signing
+              only: main
             <<: *job_filter_releases
           context:
             - sleuth-code-signing
@@ -282,9 +278,7 @@ workflows:
           arch: universal
           filters:
             branches:
-              only:
-                - main
-                - dlish/add-kms-macos-signing
+              only: main
             <<: *job_filter_releases
           context:
             - sleuth-code-signing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,10 @@ jobs:
         default: macos
       code_signer:
         type: string
-        default: 'tinyspeck/aws-ansible-code-signer-prod'
+        default: 'tinyspeck/aws-macos-code-signer-kms-prod'
       use_kms:
         type: string
-        default: 'false'
+        default: 'true'
     steps:
       - run:
           command: |
@@ -256,7 +256,9 @@ workflows:
           arch: x64
           filters:
             branches:
-              only: main
+              only:
+                - main
+                - dlish/add-kms-macos-signing
             <<: *job_filter_releases
           context:
             - sleuth-code-signing
@@ -267,7 +269,9 @@ workflows:
           arch: arm64
           filters:
             branches:
-              only: main
+              only:
+                - main
+                - dlish/add-kms-macos-signing
             <<: *job_filter_releases
           context:
             - sleuth-code-signing
@@ -278,48 +282,9 @@ workflows:
           arch: universal
           filters:
             branches:
-              only: main
-            <<: *job_filter_releases
-          context:
-            - sleuth-code-signing
-      # KMS code-sign jobs run side-by-side with existing jobs (informational only).
-      # publish depends only on the original code-sign jobs above.
-      - code-sign-macos:
-          name: code-sign-kms-macos-x64
-          requires:
-            - build-macos-x64
-          arch: x64
-          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
-          use_kms: 'true'
-          filters:
-            branches:
-              only: main
-            <<: *job_filter_releases
-          context:
-            - sleuth-code-signing
-      - code-sign-macos:
-          name: code-sign-kms-macos-arm64
-          requires:
-            - build-macos-arm64
-          arch: arm64
-          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
-          use_kms: 'true'
-          filters:
-            branches:
-              only: main
-            <<: *job_filter_releases
-          context:
-            - sleuth-code-signing
-      - code-sign-macos:
-          name: code-sign-kms-macos-universal
-          requires:
-            - build-macos-universal
-          arch: universal
-          code_signer: tinyspeck/aws-macos-code-signer-kms-prod
-          use_kms: 'true'
-          filters:
-            branches:
-              only: main
+              only:
+                - main
+                - dlish/add-kms-macos-signing
             <<: *job_filter_releases
           context:
             - sleuth-code-signing


### PR DESCRIPTION
## Summary

- Migrates macOS code signing from the legacy Ansible-based P12 keychain runners (`aws-ansible-code-signer-prod`) to KMS-Ferry runners (`aws-macos-code-signer-kms-prod`)
- Passes `USE_KMS=true` in `JOB_PARAMS` so the runner entrypoint activates KMS-Ferry mode (CryptoTokenKit-based signing via AWS KMS — no exportable private key material on the runner)
- Installer signing (pkgbuild/productbuild) still uses a keychain-based cert because Apple's tools require SHA-1 digests which KMS doesn't support

## Security improvements

- **No exportable app-signing keys on CI runners** — private key material lives in AWS KMS and is never present on disk. KMS-Ferry exposes the identity via CryptoTokenKit without extracting the key.
- **OIDC-based credential exchange** — no long-lived secrets; runners authenticate via `CIRCLE_OIDC_TOKEN` exchanged at runtime through the secrets service.
- **Branch-protected** — signing jobs only run on `main` and release tags.

## Test plan

- [x] Pushed branch with temporary branch filter to trigger signing jobs on this branch
- [x] Verified all three arch builds (x64, arm64, universal) signed successfully with KMS runners
- [x] Verified signed artifacts pass `codesign --verify` and `spctl` checks
- [ ] After merge: confirm next release tag triggers signing + publish end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)