### PR TITLE
fix: correct menu click handler type for Electron BaseWindow

### DIFF
--- a/src/main/menu-template.ts
+++ b/src/main/menu-template.ts
@@ -105,8 +105,9 @@ export function getMenuTemplate(options: MenuTemplateOptions) {
         {
           label: 'Toggle AI Sidebar',
           accelerator: 'CmdOrCtrl+L',
-          click(_item: Electron.MenuItem, browserWindow: BrowserWindow) {
-            browserWindow.webContents.send(IpcEvents.TOGGLE_AI_SIDEBAR);
+          click(_item: Electron.MenuItem, win: BaseWindow | undefined) {
+            const browserWindow = asBrowserWindow(win);
+            browserWindow?.webContents.send(IpcEvents.TOGGLE_AI_SIDEBAR);
           },
         },
       ],


### PR DESCRIPTION
## Summary
- Fix typecheck failure in `src/main/menu-template.ts` caused by Electron's updated `click` handler signature (`BaseWindow | undefined` instead of `BrowserWindow`)
- Uses the existing `asBrowserWindow` helper to safely narrow the type

## Test plan
- [x] `yarn run typecheck` passes
- [x] `yarn run lint` passes (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)