### PR TITLE
fix: avoid shell.openExternal for dev server

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -103,6 +103,15 @@ export class IpcManager {
       }
 
       window.webContents.on('will-navigate', (e, url) => {
+        // Don't open `http://localhost:5173` in the browser
+        // when running in dev mode
+        if (
+          MAIN_WINDOW_VITE_DEV_SERVER_URL &&
+          url.startsWith(MAIN_WINDOW_VITE_DEV_SERVER_URL)
+        ) {
+          return;
+        }
+
         e.preventDefault();
 
         if (!url.startsWith('file:///')) {


### PR DESCRIPTION
This has been a long-standing bug. `yarn start` opens `localhost:5173` in the browser and I couldn't figure it out for the longest time.