### PR TITLE
style(sidebar): make prefs platform-aware

### DIFF
--- a/src/renderer/components/sidebar/sidebar-rail.tsx
+++ b/src/renderer/components/sidebar/sidebar-rail.tsx
@@ -21,7 +21,20 @@ const SidebarRail = observer((props: SidebarRailProps) => {
       <SidebarBookmarks state={props.state} />
       <Divider size="small" />
       <div style={{ flex: 1 }} />
-      <Tooltip title="Preferences (⌘,)" placement="right">
+      <Tooltip
+        title={
+          <span className="SidebarRailShortcut">
+            Preferences
+            <span className="SidebarRailKeys">
+              <kbd className="SidebarRailKbd">
+                {window.Sleuth.platform === 'win32' ? 'Ctrl' : '⌘'}
+              </kbd>
+              <kbd className="SidebarRailKbd">,</kbd>
+            </span>
+          </span>
+        }
+        placement="right"
+      >
         <Button
           style={{ marginBottom: 4 }}
           icon={<SettingOutlined />}

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -18,6 +18,32 @@
   z-index: 1;
 }
 
+.SidebarRailShortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ant-margin-xs);
+}
+
+.SidebarRailKeys {
+  display: inline-flex;
+  gap: var(--ant-margin-xxs);
+}
+
+.SidebarRailKbd {
+  display: inline-block;
+  min-width: 1em;
+  padding: 1px var(--ant-padding-xxs);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-font-size-sm);
+  line-height: 1.3;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.12);
+  border: var(--ant-line-width) solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--ant-border-radius-sm);
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.4);
+}
+
 .SidebarTreeToggle {
   --overlap-height: 4px;
   width: 100%;

--- a/test/vitest-setup.js
+++ b/test/vitest-setup.js
@@ -8,6 +8,24 @@ globalThis.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// Default mock for the `window.Sleuth` preload API. Real values are provided
+// for the fields components branch on; any other property resolves to a no-op mock.
+// `setup*` methods in the real API return a cleanup function, so the fallback
+// returns one too.
+window.Sleuth = new Proxy(
+  {
+    platform: 'darwin',
+    versions: {},
+    sleuthVersion: '0.0.0-test',
+  },
+  {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      return vi.fn(() => vi.fn());
+    },
+  },
+);
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: vi.fn().mockImplementation((query) => ({


### PR DESCRIPTION
* Cmd becomes Ctrl on Windows.
* Adds keyboard-specific styles so it looks more like <kbd>Ctrl</kbd>

<img width="228" height="103" alt="image" src="https://github.com/user-attachments/assets/0f92d4ee-0515-44f3-9223-0978e27409fc" />
